### PR TITLE
V0.6.5

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -38,7 +38,7 @@ const appStore = useAppStore()
 nuxtApp.provide("emitter", emitter)
 appStore.setEmitter(emitter)
 
-const appVersion = ref<string>("0.6.4")
+const appVersion = ref<string>("0.6.5")
 
 const registerServiceWorker = async () => {
   if ("serviceWorker" in navigator) {

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -398,6 +398,9 @@ body {
 .tiptap.live-content .song-content {
   font-weight: 600;
 }
+.tiptap.live-content .countdown-content {
+  font-weight: 600;
+}
 .tiptap.live-content:focus-within {
   outline-color: #e9d5ff;
 }
@@ -508,12 +511,18 @@ body {
   font-size: 1.5vw;
 }
 
+.tiptap.live-content .countdown-label {
+  margin-top: 5%;
+  font-size: 3vw;
+}
+
 .tiptap.live-content .copyright-content {
   font-size: 1vw;
   margin-top: 1%;
   max-width: 50%;
   color: #ffffff80;
 }
+
 .center-live-content .copyright-content {
   margin-right: auto;
   margin-left: auto;
@@ -536,12 +545,14 @@ body {
   line-height: 1.1vw;
 }
 .lg-preview .tiptap.live-content .scripture-content,
+.lg-preview .tiptap.live-content .countdown-content,
 .lg-preview .tiptap.live-content .song-content {
   font-size: 0.8vw !important;
   line-height: 1.1vw !important;
 }
 
 .lg-preview .tiptap.live-content .scripture-label,
+.lg-preview .tiptap.live-content .countdown-label,
 .lg-preview .tiptap.live-content .song-label {
   font-size: 0.5vw;
 }
@@ -593,6 +604,7 @@ body {
 }
 
 .md-preview .tiptap.live-content .scripture-label,
+.md-preview .tiptap.live-content .countdown-label,
 .md-preview .tiptap.live-content .song-label {
   font-size: 0.15vw;
 }
@@ -603,6 +615,7 @@ body {
 }
 
 .md-preview .tiptap.live-content .scripture-content,
+.md-preview .tiptap.live-content .countdown-content,
 .md-preview .tiptap.live-content .song-content {
   font-size: 0.4vw !important;
   line-height: 0.6vw !important;
@@ -646,12 +659,14 @@ body {
 }
 
 .sm-preview .tiptap.live-content .scripture-content,
+.sm-preview .tiptap.live-content .countdown-content,
 .sm-preview .tiptap.live-content .song-content {
   font-size: 0.2vw !important;
   line-height: 0.3vw !important;
 }
 
 .sm-preview .tiptap.live-content .scripture-label,
+.sm-preview .tiptap.live-content .countdown-label,
 .sm-preview .tiptap.live-content .song-label {
   font-size: 0.2vw;
 }

--- a/components/ActionCard.vue
+++ b/components/ActionCard.vue
@@ -2,7 +2,12 @@
   <button
     class="action-card flex gap-3 p-2 py-4 border-t first:border-t-0 border-gray-100 dark:border-primary-950 hover:rounded-md hover:bg-primary-50 dark:hover:bg-primary-800 transition-all cursor-pointer text-left w-[100%]"
     :class="{ 'pointer-events-none opacity-30': action?.unreleased }"
-    @click="useGlobalEmit(action?.action, emitParameter)"
+    @click="
+      useGlobalEmit(
+        `${action?.action}${actionSuffix ? `-${actionSuffix}` : ''}`,
+        emitParameter
+      )
+    "
   >
     <IconWrapper
       :name="action?.icon"
@@ -33,6 +38,7 @@ import type { QuickAction } from "~/types"
 
 const props = defineProps<{
   action: QuickAction
+  actionSuffix: String
 }>()
 
 const emitParameter = computed(() => {

--- a/components/ActionCard.vue
+++ b/components/ActionCard.vue
@@ -44,9 +44,9 @@ const props = defineProps<{
 const emitParameter = computed(() => {
   switch (props.action?.type) {
     case slideTypes.bible:
-      return `${props.action?.bibleBookIndex}:${
-        props.action?.bibleChapterAndVerse || "1:1"
-      }`
+      return props.action?.bibleChapterAndVerse
+        ? `${props.action?.bibleBookIndex}:${props.action?.bibleChapterAndVerse}`
+        : ""
     case slideTypes.hymn:
       return `${props.action?.hymnIndex}`
     default:

--- a/components/AddAlert.vue
+++ b/components/AddAlert.vue
@@ -5,9 +5,9 @@
       class="active-alert rounded-md bg-primary-100 dark:bg-primary-900 py-4 mb-4"
     >
       <div
-        class="text-sm font-semibold flex items-center gap-2 text-gray-500 px-4 pb-2"
+        class="text-sm font-semibold flex items-center gap-2 text-primary-900 dark:text-primary-100 px-4 pb-3 border-b border-primary-200"
       >
-        <IconWrapper name="i-bx-info-circle" size="4"></IconWrapper>
+        <!-- <IconWrapper name="i-bx-info-circle" size="4"></IconWrapper> -->
         Alert Schedule (Maximum of 3)
       </div>
       <div

--- a/components/AddCountdown.vue
+++ b/components/AddCountdown.vue
@@ -1,0 +1,89 @@
+<template>
+  <div class="add-song-main mb-4">
+    <h2 class="font-semibold text-md">Add Countdown</h2>
+    <form class="flex flex-col gap-3 mt-2">
+      <!-- <UFormGroup size="xl">
+        <div class="flex items-center gap-2">
+          <UInput type="number" class="text-xs" />
+          <span class="text-2xl">h</span>
+        </div>
+      </UFormGroup> -->
+
+      <UFormGroup size="lg">
+        <USelectMenu
+          variant="solid"
+          color="black"
+          placeholder="Alert position"
+          class="text-gray-400"
+          value-attribute="value"
+          v-model="time"
+          :ui="{
+            variant: {
+              solid: 'focus:ring-0 bg-gray-100',
+            },
+          }"
+          :options="[
+            { label: '5 minutes', value: '00:05:00' },
+            { label: '10 minutes', value: '00:10:00' },
+            { label: '15 minutes', value: '00:15:00' },
+            { label: '30 minutes', value: '00:30:00' },
+            { label: '45 minutes', value: '00:45:00' },
+          ]"
+        >
+          <template #label>
+            <span v-if="time?.length" class="truncate text-black">{{
+              time
+            }}</span>
+            <span v-else>Countdown duration</span>
+          </template>
+        </USelectMenu>
+      </UFormGroup>
+      <UFormGroup size="lg">
+        <UTextarea
+          placeholder="Optional text above your countdown e.g 'Time before service starts:'"
+          variant="none"
+          rows="4"
+          color="gray"
+          resize="vertical"
+          v-model="content"
+        />
+      </UFormGroup>
+
+      <UButton
+        block
+        icon="i-bx-add"
+        size="lg"
+        class="mt-4"
+        :disabled="!time"
+        :loading="loading"
+        @click="createCountdown"
+      >
+        Create countdown slide
+      </UButton>
+    </form>
+  </div>
+</template>
+<script setup lang="ts">
+import { useAppStore } from "~/store/app"
+import type { Countdown } from "~/types"
+import type { Emitter } from "mitt"
+
+const emitter = useNuxtApp().$emitter as Emitter<any>
+
+const appStore = useAppStore()
+const loading = ref<boolean>(false)
+const content = ref<string>("")
+const time = ref<string>("00:05:00")
+const toast = useToast()
+const emit = defineEmits(["go-home"])
+
+const createCountdown = async () => {
+  const countdown: Countdown = {
+    id: useID(),
+    content: content.value,
+    time: time.value,
+    timeLeft: time.value,
+  }
+  emitter.emit("new-countdown", countdown)
+}
+</script>

--- a/components/AddMedia.vue
+++ b/components/AddMedia.vue
@@ -19,7 +19,7 @@
       <input
         type="file"
         class="invisible"
-        accept="video/*,image/*"
+        accept="video/*,image/*,audio/*"
         multiple
         @change="files = $event.target?.files"
       />

--- a/components/AddMedia.vue
+++ b/components/AddMedia.vue
@@ -108,7 +108,6 @@ const fileObjs = computed(() => {
   const tempArr: any[] = []
   files.value?.forEach((file: any) => {
     if (file) {
-      console.log(file)
       tempArr.push({
         blob: file,
         name: file?.name,

--- a/components/AddMedia.vue
+++ b/components/AddMedia.vue
@@ -9,7 +9,7 @@
         class="py-4"
         rounded-bg
       ></IconWrapper>
-      <h4 class="text-md mt-4 font-medium">Add image or video slides</h4>
+      <h4 class="text-md mt-4 font-medium">Add image, video or audio slides</h4>
       <div
         class="text-center max-w-[150px] mx-auto px-4 py-1 mt-4 bg-primary-500 rounded-md flex items-center text-white cursor-pointer gap-1"
       >
@@ -32,7 +32,11 @@
         class="bg-primary-100 dark:bg-primary-900 rounded-md p-4 py-2 text-md font-semibold capitalize mb-2"
       >
         Media Preview
-        <span class="font-normal">({{ fileObjs?.length }} images/videos)</span>
+        <span class="font-normal"
+          >({{ fileObjs?.length }} file{{
+            fileObjs?.length > 1 ? "s" : ""
+          }})</span
+        >
       </h3>
       <Transition name="fade-sm">
         <div
@@ -51,6 +55,14 @@
               alt="previewed slide image"
               class="rounded-md max-h-[40vh] 2xl:max-h-[100%] bg-primary-950"
             />
+            <audio
+              v-if="fileObj?.type === 'audio'"
+              alt="previewed slide image"
+              controls
+              class="max-h-[40vh] 2xl:max-h-[100%] w-[100%]"
+            >
+              <source :src="fileObj.url" type="audio/mp3" />
+            </audio>
             <video
               v-else
               :src="fileObj.url"

--- a/components/AlertView.vue
+++ b/components/AlertView.vue
@@ -2,18 +2,18 @@
   <!-- 1 char = 0.25s -->
   <Transition name="fade-sm">
     <div
-      v-if="alert"
+      v-if="activeAlert"
       class="marquee w-[100%] absolute font-bold flex come-up-1"
-      :style="`background: ${alert.background}`"
-      :class="alert.style"
+      :style="`background: ${activeAlert.background}`"
+      :class="activeAlert.style"
     >
       <IconWrapper
-        :name="alert.icon"
+        :name="activeAlert.icon"
         class="bg-primary-900 z-10 px-[1.5vw]"
         size="8"
       />
       <div class="inner" :style="`animation-duration: ${animationDuration}`">
-        {{ alert?.title }}
+        {{ activeAlert?.title }}
       </div>
     </div>
   </Transition>
@@ -21,11 +21,12 @@
 
 <script setup lang="ts">
 import { useAppStore } from "~/store/app"
+import type { Alert } from "~/types"
 const appStore = useAppStore()
 
-const { alert } = storeToRefs(appStore)
+const { alerts, activeAlert } = storeToRefs(appStore)
 const animationDuration = computed(() => {
   // 1 char = 0.25s - Standard Calc
-  return `${alert.value?.title.length}s`
+  return `${activeAlert.value?.title.length}s`
 })
 </script>

--- a/components/BgImageSelection.vue
+++ b/components/BgImageSelection.vue
@@ -1,6 +1,8 @@
 <template>
   <div class="bg-image-selection-ctn p-2">
-    <div class="bg-image-selection gap-2 grid grid-cols-4">
+    <div
+      class="bg-image-selection gap-2 grid grid-cols-4 max-h-[190px] overflow-y-auto"
+    >
       <UButton
         v-for="image in backgroundImages"
         :key="image"

--- a/components/BgVideoSelection.vue
+++ b/components/BgVideoSelection.vue
@@ -1,6 +1,8 @@
 <template>
   <div class="bg-image-selection-ctn p-2">
-    <div class="bg-image-selection gap-2 grid grid-cols-3">
+    <div
+      class="bg-image-selection gap-2 grid grid-cols-3 max-h-[200px] overflow-y-auto"
+    >
       <UButton
         v-for="(video, index) in backgroundVideos"
         :key="video"

--- a/components/BgVideoSelection.vue
+++ b/components/BgVideoSelection.vue
@@ -95,7 +95,8 @@ const saveAndSelectVideo = async (file: any) => {
   db.cached.add(tempMedia)
   bgVideoToBeSelected.value = tempMedia.id
   await getAllLocallySavedVideos()
-  emit("select", bgVideoToBeSelected.value)
+  console.log(bgVideoToBeSelected.value, tempMedia.id)
+  emit("select", { video: bgVideoToBeSelected.value, key: tempMedia.id })
 }
 
 getAllLocallySavedVideos()

--- a/components/BgVideoSelection.vue
+++ b/components/BgVideoSelection.vue
@@ -1,37 +1,58 @@
 <template>
-  <div class="bg-image-selection p-2 gap-2 grid grid-cols-3">
-    <UButton
-      v-for="(video, index) in backgroundVideos"
-      :key="video"
-      @click="$emit('select', { video, key: `/video-bg-${index + 1}.mp4` })"
-      class="min-w-[80px] h-[60px] p-0 text-black bg-cover transition-all overflow-hidden relative"
-    >
-      <video
-        class="bg-image w-[100%] h-[100%] transition rounded-md opacity-100 hover:opacity-30 object-cover"
-        :class="{ 'opacity-30': video === value }"
-        :src="video"
-        muted
-        autoplay
-        crossorigin="anonymous"
-      ></video>
-      <IconWrapper
-        v-if="video === value"
-        name="i-bx-check"
-        size="5"
-        :rounded-bg="true"
-        class="absolute text-primary-500 scale-50 bottom-2 right-2"
-      />
-    </UButton>
+  <div class="bg-image-selection-ctn p-2">
+    <div class="bg-image-selection gap-2 grid grid-cols-3">
+      <UButton
+        v-for="(video, index) in backgroundVideos"
+        :key="video"
+        @click="$emit('select', { video, key: `/video-bg-${index + 1}.mp4` })"
+        class="min-w-[80px] h-[60px] p-0 text-black bg-cover transition-all overflow-hidden relative"
+      >
+        <video
+          class="bg-image w-[100%] h-[100%] transition rounded-md opacity-100 hover:opacity-30 object-cover"
+          :class="{ 'opacity-30': video === value }"
+          :src="video"
+          muted
+          autoplay
+          crossorigin="anonymous"
+        ></video>
+        <IconWrapper
+          v-if="video === value"
+          name="i-bx-check"
+          size="5"
+          :rounded-bg="true"
+          class="absolute text-primary-500 scale-50 bottom-2 right-2"
+        />
+      </UButton>
+    </div>
+    <div class="button-ctn pt-2">
+      <label class="relative">
+        <input
+          type="file"
+          name=""
+          id=""
+          class="absolute inset-0 opacity-0 cursor-pointer"
+          accept="video/*"
+          @change="saveAndSelectVideo($event.target?.files?.[0])"
+        />
+        <UButton class="z-1" block variant="outline" icon="i-bx-plus" size="xs"
+          >Add from device</UButton
+        >
+      </label>
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
 import { useAppStore } from "~/store/app"
+import type { Media } from "~/types"
 const appStore = useAppStore()
 
 defineProps<{
   value: string
 }>()
+
+const emit = defineEmits(["select"])
+
 const backgroundVideoKeys = [
   "/video-bg-1.mp4",
   "/video-bg-2.mp4",
@@ -40,7 +61,42 @@ const backgroundVideoKeys = [
   "/video-bg-5.mp4",
   "/video-bg-6.mp4",
 ]
+const bgVideoToBeSelected = ref<string | null>(null)
 const backgroundVideos = ref(appStore.backgroundVideos)
+
+const getAllLocallySavedVideos = async () => {
+  const db = useIndexedDB()
+  const videos = await db.cached.where({ content: "video" }).toArray()
+
+  // Create Object URLs from locally saved images
+  const videoURLs: string[] = []
+  videos.forEach((video) => {
+    const blobURL = URL.createObjectURL(video.data as unknown as Blob)
+    videoURLs.push(blobURL)
+    if (video.id === bgVideoToBeSelected.value) {
+      bgVideoToBeSelected.value = blobURL
+    }
+  })
+  backgroundVideos.value = backgroundVideos.value.concat(videoURLs)
+}
+
+const saveAndSelectVideo = async (file: any) => {
+  const db = useIndexedDB()
+  const randomId = useID(6)
+  const tempMedia: Media = {
+    id: `/custom-video-bg-${randomId}.${file.type?.split("/")?.[1]}`,
+    data: file,
+    content: "video",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  }
+  db.cached.add(tempMedia)
+  bgVideoToBeSelected.value = tempMedia.id
+  await getAllLocallySavedVideos()
+  emit("select", bgVideoToBeSelected.value)
+}
+
+getAllLocallySavedVideos()
 
 // onBeforeUnmount(() => {
 //   backgroundVideos?.value?.forEach((url) => {

--- a/components/BibleList.vue
+++ b/components/BibleList.vue
@@ -1,0 +1,147 @@
+<template>
+  <div class="song-main min-h-[90vh]" ref="quickActions">
+    <div class="flex gap-2">
+      <UInput
+        icon="i-bx-search"
+        placeholder="Search scriptures"
+        v-model="searchInput"
+        class="w-[100%]"
+        @input="onSearchInput"
+        @keyup.enter="getSongs($event.target.value)"
+      />
+      <UButton icon="i-bx-x" color="primary" @click="$emit('close')"></UButton>
+    </div>
+
+    <!-- SEARCHING BIBLE VERSES -->
+    <div
+      v-if="searchInput.length >= 2"
+      class="actions-ctn mt-2 overflow-y-auto max-h-[calc(100vh-180px)]"
+    >
+      <ActionCard
+        v-for="(action, index) in searchedActions"
+        :key="action?.name"
+        :action="{ ...action, bibleChapterAndVerse }"
+        :class="{
+          'bg-primary-50 dark:bg-primary-800 rounded-md':
+            index === focusedActionIndex,
+        }"
+      />
+    </div>
+
+    <!-- RECENTLY OPENED SCRIPTURES -->
+    <div
+      v-if="recentBibleSearches.length > 0 && searchInput.length < 2"
+      class="actions-ctn mt-2 overflow-y-auto max-h-[calc(100vh-180px)]"
+    >
+      <BibleQueryCard
+        v-for="bibleQuery in recentBibleSearches"
+        :key="bibleQuery"
+        :bible-query="bibleQuery"
+        type="song"
+      />
+    </div>
+
+    <EmptyState
+      v-if="recentBibleSearches?.length === 0 && searchInput.length < 2"
+      icon="i-tabler-cloud-search"
+      sub="You haven't opened any scriptures yet"
+      action-text="Open Genesis 1"
+      action="bible-search-demo"
+    />
+  </div>
+</template>
+<script setup lang="ts">
+import type { QuickAction, Song } from "~/types"
+import { useDebounceFn } from "@vueuse/core"
+import { useAppStore } from "~/store/app"
+let searchInputBeforeTwoDigitNumbers = ""
+import fuzzysort from "fuzzysort"
+
+const props = defineProps<{
+  query: string
+}>()
+
+const { recentBibleSearches } = storeToRefs(useAppStore())
+const searchInput = ref<string>(props.query || "")
+const focusedActionIndex = ref(0)
+const quickActions = ref<HTMLDivElement | null>(null)
+const actions = ref<QuickAction[]>([])
+
+watch(
+  () => props.query,
+  () => {
+    searchInput.value = props.query
+  }
+)
+
+// Initialize actions
+const scriptureActions: QuickAction[] = bibleBooks?.map((book, index) => {
+  const bibleBookIndex = index + 1 // Does not start from 0, starts from 1
+  return {
+    icon: "i-bx-bible",
+    name: `${book}`,
+    desc: `Open the book of ${book}`,
+    action: "new-bible",
+    meta: `${book} 0:0 1:1 2:2 3:3 4:4 5:5 6:6 7:7 8:8 9:9 10:10 -`,
+    searchableOnly: true,
+    bibleBookIndex,
+    type: slideTypes.bible,
+  }
+})
+actions.value = scriptureActions
+
+const bibleChapterAndVerse = computed(() => {
+  const regex = /\b\d+\s*:\s*\d+\b/g
+  return searchInput.value.match(regex)?.[0]?.replaceAll(" ", "")
+})
+
+const searchedActions = computed(() => {
+  const twoDigitNumbers = searchInput.value?.match(/\b\d{2}\b/g)
+
+  // Stop search if input includes two digit number
+  if (!twoDigitNumbers) {
+    searchInputBeforeTwoDigitNumbers = searchInput.value
+  }
+
+  focusedActionIndex.value = 0
+  const colonIndex = searchInputBeforeTwoDigitNumbers?.indexOf(":")
+  const searchInputBeforeColon =
+    colonIndex === -1
+      ? searchInputBeforeTwoDigitNumbers
+      : searchInputBeforeTwoDigitNumbers?.substring(0, colonIndex)
+
+  let results = fuzzysort.go(searchInputBeforeColon, actions.value, {
+    keys: ["name", "desc", "meta"],
+  })
+  results = results?.map((result) => result.obj)
+
+  // Sort by showing [searchableOnly] actions last
+  results.sort((a, b) => {
+    if (a.searchableOnly && !b.searchableOnly) {
+      return 1
+    } else if (!a.searchableOnly && b.searchableOnly) {
+      return -1
+    } else {
+      return 0
+    }
+  })
+
+  // If true, then show Bible types first.
+  if (bibleChapterAndVerse.value) {
+    results.sort((a, b) => {
+      if (a.type === "bible" && b.type !== "bible") {
+        return -1
+      } else if (a.type !== "bible" && b.type === "bible") {
+        return 1
+      } else {
+        return 0
+      }
+    })
+  }
+  return results?.slice(0, 10)
+})
+
+const onSearchInput = useDebounceFn(async () => {
+  // getSongs(searchInput.value)
+}, 1000)
+</script>

--- a/components/BibleQueryCard.vue
+++ b/components/BibleQueryCard.vue
@@ -1,0 +1,27 @@
+<template>
+  <button
+    class="action-card flex gap-3 p-2 py-4 border-t first:border-t-0 border-gray-100 dark:border-primary-950 hover:rounded-md hover:bg-primary-50 dark:hover:bg-primary-800 transition-all cursor-pointer text-left w-[100%]"
+    @click="useGlobalEmit('new-bible', bibleQuery)"
+  >
+    <IconWrapper
+      name="i-bx-history"
+      class="mt-1 text-primary dark:text-primary-300"
+      rounded-bg
+    />
+    <div class="texts">
+      <h4 class="font-semibold">
+        {{ useScriptureLabel(bibleQuery, { toLongForm: true }) }}
+      </h4>
+      <p class="font-light text-xs mt-1">Recently opened</p>
+    </div>
+  </button>
+</template>
+<script setup lang="ts">
+import type { QuickAction } from "~/types"
+
+const props = defineProps<{
+  bibleQuery: string
+}>()
+</script>
+
+<style scoped></style>

--- a/components/ChangelogModal.vue
+++ b/components/ChangelogModal.vue
@@ -51,9 +51,14 @@ defineProps<{
 
 const emitter = useNuxtApp().$emitter as Emitter<any>
 const changelog = `
-- Added full text search for songs: you can now search by artists, the actual song lyrics or even an album name.
-- You can now search for songs from quick actions home.
-- Fixed: Recurring download of assets on reload.`
+- You can now add your own images and videos as backgrounds for your slides.
+- We've added support for your audio-only files for media slides. Just go ahead and create a media slide and see the customizations you can add to your media(audio) slide.
+- You can now play, pause and restart your media files with the Media slide controls.
+- One alert is not enough, we added an alert scheduler so you can store alerts and take any one live as you wish.
+- This one is exciting! We added a countdown timer for your convenience. Now you can let your congregation know what how soon an event starts or finish in an exciting manner.
+- Sharing is caring; now other people can use the songs you upload—but only if you want.
+- We don't want you to ever make a mistake taking slides LIVE. So we added a two-step feature to the "Display Bible" action on the quick actions pane.
+- Want to edit a live slide quickly, double tap the slide in the Live Output pane and make your quick adjustments ;)`
 
 const appStore = useAppStore()
 

--- a/components/EditLiveContent.vue
+++ b/components/EditLiveContent.vue
@@ -119,7 +119,11 @@
               </template>
             </UPopover>
             <div
-              v-show="slide?.type !== slideTypes.media"
+              v-show="
+                slide?.type !== slideTypes.media ||
+                (slide?.type === slideTypes.media &&
+                  slide?.data?.type?.includes('audio'))
+              "
               class="button-group flex rounded-md mx-1 p-1"
               :class="{
                 'bg-primary-200 dark:bg-primary-900':
@@ -155,7 +159,10 @@
                   />
                 </template>
               </UPopover>
-              <UPopover v-model:open="bgVideoPopoverOpen">
+              <UPopover
+                v-if="!slide?.data?.type?.includes('audio')"
+                v-model:open="bgVideoPopoverOpen"
+              >
                 <UTooltip text="Add background video" :popper="{ arrow: true }">
                   <UButton
                     variant="ghost"

--- a/components/EditLiveContent.vue
+++ b/components/EditLiveContent.vue
@@ -14,7 +14,11 @@
               <h4 class="font-medium text-nowrap">
                 {{ useShortSlideName(slide, { longer: true }) }}
               </h4>
-              <SlideChip :slide-type="slide?.type" dark-mode />
+              <SlideChip
+                :slide-type="slide?.type"
+                :slide-sub-type="slide?.data?.type"
+                dark-mode
+              />
             </div>
           </TransitionGroup>
           <div class="actions flex items-center ml-6">

--- a/components/EditLiveContent.vue
+++ b/components/EditLiveContent.vue
@@ -104,7 +104,7 @@
               v-if="slide?.type === slideTypes?.bible"
               @change="$emit('update-bible-version', $event)"
             />
-            <UPopover
+            <!-- <UPopover
               v-if="slide?.layout !== slideLayoutTypes.bible"
               v-model:open="layoutPopoverOpen"
             >
@@ -121,7 +121,7 @@
                   @select="onSelectLayout"
                 />
               </template>
-            </UPopover>
+            </UPopover> -->
             <div
               v-show="
                 slide?.type !== slideTypes.media ||

--- a/components/EmptyState.vue
+++ b/components/EmptyState.vue
@@ -1,8 +1,9 @@
 <template>
-  <div class="h-[88%] mt-4 flex flex-col items-center justify-center gap-4 text-gray-500">
+  <div
+    class="h-[88%] mt-4 flex flex-col items-center justify-center gap-4 text-gray-500"
+  >
     <IconWrapper :name="icon" size="14" />
     <div>
-
       <h2 class="text-md font-semibold max-w-[150px] text-center">
         {{ sub }}
       </h2>

--- a/components/LiveOutput.vue
+++ b/components/LiveOutput.vue
@@ -42,6 +42,7 @@
               'bg-red-100 dark:bg-red-900': liveSlide?.id === slide?.id,
             }"
             @click="appStore.setLiveSlide(slide?.id || '0')"
+            @dblclick="useGlobalEmit('new-active-slide', slide)"
           >
             <div
               class="slide-preview w-24 min-w-24 h-16 text-white overflow-hidden sm-preview relative"

--- a/components/LiveProjectionOnly.vue
+++ b/components/LiveProjectionOnly.vue
@@ -19,6 +19,19 @@
       @dblclick="activateFullScreen()"
       :style="useSlideBackground(slide)"
     >
+      <!-- AUDIO BACKGROUND -->
+      <audio
+        ref="video"
+        v-if="slide?.data?.type?.includes('audio')"
+        :src="slide?.data?.url"
+        autoplay
+        :loop="
+          slide?.type !== slideTypes.media || slide?.slideStyle?.repeatMedia
+        "
+        :muted="fullScreen ? slide?.slideStyle?.isMediaMuted : true"
+        playsinline="true"
+        crossorigin="anonymous"
+      ></audio>
       <!-- VIDEO BACKGROUND -->
       <video
         ref="video"

--- a/components/Navbar.vue
+++ b/components/Navbar.vue
@@ -7,11 +7,12 @@
       <div class="logo flex items-center gap-2">
         <Logo class="w-[32px]" />
         <h1 class="text-md font-semibold">Cloud of Worshippers</h1>
-        <span
-          class="version-chip flex text-xs font-semibold bg-gray-100 dark:bg-primary-900 p-2 py-1 rounded-full dark:bg-primary-900"
+        <UButton
+          class="version-chip flex text-xs font-semibold bg-primary-500 p-2 py-1 rounded-full border border-primary-500 hover:border-primary-900 transition-all"
+          @click="useGlobalEmit('show-changelog')"
         >
           v{{ appVersion }}
-        </span>
+        </UButton>
       </div>
       <div class="actions text-sm flex gap-2 items-center">
         <ClientOnly>

--- a/components/Navbar.vue
+++ b/components/Navbar.vue
@@ -8,10 +8,10 @@
         <Logo class="w-[32px]" />
         <h1 class="text-md font-semibold">Cloud of Worshippers</h1>
         <UButton
-          class="version-chip flex text-xs font-semibold bg-primary-500 p-2 py-1 rounded-full border border-primary-500 hover:border-primary-900 transition-all"
+          class="version-chip flex text-xs font-semibold bg-primary-200 p-2 py-1 rounded-full border border-transparent hover:bg-primary-300 hover:border-primary-900 transition-all text-primary-900"
           @click="useGlobalEmit('show-changelog')"
         >
-          v{{ appVersion }}
+          Beta v{{ appVersion }}
         </UButton>
       </div>
       <div class="actions text-sm flex gap-2 items-center">

--- a/components/PreviewContent.vue
+++ b/components/PreviewContent.vue
@@ -804,6 +804,9 @@ const removeFromSelectedSlides = (slideId: string) => {
 </script>
 
 <style scoped>
+.slides-ctn {
+  scroll-behavior: smooth;
+}
 .slides-ctn-3-rows {
   height: 336px;
 }

--- a/components/PreviewContent.vue
+++ b/components/PreviewContent.vue
@@ -379,9 +379,12 @@ const createNewMediaSlide = async (
     })
   }
 
+  const randomImage =
+    "https://images.unsplash.com/photo-1515162305285-0293e4767cc2?q=80&w=1740"
   tempSlide.type = slideTypes.media
-  tempSlide.backgroundType = file.type
-  tempSlide.background = file.url
+  tempSlide.slideStyle.backgroundFillType = backgroundFillTypes.crop
+  tempSlide.backgroundType = file.type === "audio" ? "image" : file.type
+  tempSlide.background = file.type === "audio" ? randomImage : file.url
   tempSlide.data = file
   tempSlide.name = useSlideName(tempSlide)
 

--- a/components/PreviewContent.vue
+++ b/components/PreviewContent.vue
@@ -135,9 +135,12 @@ emitter.on("new-text", (slide: Slide) => {
 })
 
 emitter.on("new-bible", async (data: string) => {
-  const scripture = await useScripture(data)
-  if (scripture) {
-    createNewBibleSlide(scripture)
+  if (data) {
+    const scripture = await useScripture(data)
+    if (scripture) {
+      createNewBibleSlide(scripture)
+      appStore.setRecentBibleSearches(data)
+    }
   }
 })
 
@@ -145,6 +148,7 @@ emitter.on("new-bible-whole-search", async (data: string) => {
   const scripture = await useScripture(data)
   if (scripture) {
     createNewBibleSlide(scripture, { fromWholeBibleSearch: true })
+    appStore.setRecentBibleSearches(data)
   }
 })
 

--- a/components/PreviewContent.vue
+++ b/components/PreviewContent.vue
@@ -141,6 +141,13 @@ emitter.on("new-bible", async (data: string) => {
   }
 })
 
+emitter.on("new-bible-whole-search", async (data: string) => {
+  const scripture = await useScripture(data)
+  if (scripture) {
+    createNewBibleSlide(scripture, { fromWholeBibleSearch: true })
+  }
+})
+
 emitter.on("new-hymn", async (data: string) => {
   const hymn = await useHymn(data)
   if (hymn) {
@@ -256,7 +263,7 @@ const deleteSlide = async (slideId: string, addToast: boolean = true) => {
 
   // Clear interval if slide is a countdown slide before deleting
   if (tempSlide?.type === slideTypes.countdown) {
-    console.log("clearing interval", activeCountdownInterval.value)
+    // console.log("clearing interval", activeCountdownInterval.value)
     clearInterval(activeCountdownInterval.value)
     countdownTimeLeft.value = 0
   }
@@ -307,7 +314,10 @@ const onUpdateSlide = (slide: Slide) => {
   }
 }
 
-const createNewBibleSlide = (scripture: Scripture) => {
+const createNewBibleSlide = (
+  scripture: Scripture,
+  options?: { fromWholeBibleSearch: boolean }
+) => {
   const tempSlide = { ...preSlideCreation() }
   tempSlide.layout = slideLayoutTypes.bible
   tempSlide.type = slideTypes.bible
@@ -327,7 +337,7 @@ const createNewBibleSlide = (scripture: Scripture) => {
   tempSlide.contents = useSlideContent(tempSlide, scripture)
 
   slides.value?.push(tempSlide)
-  makeSlideActive(tempSlide, true)
+  makeSlideActive(tempSlide, !options?.fromWholeBibleSearch)
   toast.add({ title: "Bible slide created", icon: "i-bx-bible" })
 }
 
@@ -384,7 +394,7 @@ const createNewSongSlide = (song: Song) => {
 
   slides.value?.push(tempSlide)
   makeSlideActive(tempSlide)
-  console.log("called")
+  // console.log("called")
   toast.add({ title: "Song slide created", icon: "i-bx-music" })
 }
 
@@ -455,7 +465,7 @@ const removeExistingCountdownSlides = () => {
  * @param countdown
  */
 const createNewCountdownSlide = (countdown: Countdown) => {
-  console.log(activeSlide.value)
+  // console.log(activeSlide.value)
   // Only one countdown slide can be active, clear any active interval
   removeExistingCountdownSlides()
   clearInterval(activeCountdownInterval.value)
@@ -546,9 +556,8 @@ const startCountdown = (slide: Slide, restartCountdown: boolean = false) => {
         updateCountdownSlide(slide, countdownTimeLeft.value, false)
       }, countdownTimeout)
     } else {
-      const countdownTimeout = useTimeStringToMilli(slide.data?.timeLeft)
-      console.log("reached pause section", activeCountdownInterval.value)
-      console.log("reached pause section", countdownTimeLeft.value)
+      // console.log("reached pause section", activeCountdownInterval.value)
+      // console.log("reached pause section", countdownTimeLeft.value)
       clearInterval(activeCountdownInterval.value)
       activeCountdownInterval.value = null
       updateCountdownSlide(slide, countdownTimeLeft.value, false)

--- a/components/PreviewContent.vue
+++ b/components/PreviewContent.vue
@@ -133,15 +133,15 @@ emitter.on("new-text", (slide: Slide) => {
   createNewSlide(slide)
 })
 
-emitter.on("new-bible", (data: string) => {
-  const scripture = useScripture(data)
+emitter.on("new-bible", async (data: string) => {
+  const scripture = await useScripture(data)
   if (scripture) {
     createNewBibleSlide(scripture)
   }
 })
 
-emitter.on("new-hymn", (data: string) => {
-  const hymn = useHymn(data)
+emitter.on("new-hymn", async (data: string) => {
+  const hymn = await useHymn(data)
   if (hymn) {
     createNewHymnSlide(hymn)
   }
@@ -431,7 +431,7 @@ const gotoAction = (title: string, version: string) => {
   }
 }
 
-const gotoScripture = (title: string, version: string) => {
+const gotoScripture = async (title: string, version: string) => {
   // Check that [title] is not abbreviated or in short form
   // If it is, replace to long/unabbreviated form
   let bibleBook = title.substring(0, title?.lastIndexOf(" "))
@@ -451,7 +451,7 @@ const gotoScripture = (title: string, version: string) => {
   }:${scriptureSplitted?.[2]}`
   const scriptureShortLabel = `${scriptureSplitted?.[0]}:${scriptureSplitted?.[1]}:${scriptureSplitted?.[2]}`
 
-  const scripture = useScripture(scriptureShortLabel, version)
+  const scripture = await useScripture(scriptureShortLabel, version)
   if (scripture) {
     // Calculate font-size of scripture content
     tempSlide.title = scriptureLabel

--- a/components/PreviewContent.vue
+++ b/components/PreviewContent.vue
@@ -630,10 +630,10 @@ const gotoScripture = async (title: string, version: string) => {
   }
 }
 
-const gotoHymnVerse = (title: string) => {
+const gotoHymnVerse = async (title: string) => {
   const tempSlide = { ...activeSlide.value } as Slide
   const slideIndex = slides.value.findIndex((s) => s.id === tempSlide.id)
-  const hymn = useHymn(tempSlide.songId as string)
+  const hymn = await useHymn(tempSlide.songId as string)
   const realTitle = title
 
   if (hymn) {
@@ -683,10 +683,10 @@ const gotoSongVerse = (title: string) => {
   }
 }
 
-const gotoChorus = () => {
+const gotoChorus = async () => {
   const tempSlide = { ...activeSlide.value } as Slide
   const slideIndex = slides.value.findIndex((s) => s.id === tempSlide.id)
-  const hymn = useHymn(tempSlide.songId as string)
+  const hymn = await useHymn(tempSlide.songId as string)
 
   if (hymn) {
     const chorus = hymn?.chorus as string

--- a/components/PreviewVerses.vue
+++ b/components/PreviewVerses.vue
@@ -81,7 +81,6 @@ const getAllChapterVerses = async () => {
 watch(
   bibleChapter,
   () => {
-    console.log("updated bible chapter")
     getAllChapterVerses()
   },
   { immediate: true }
@@ -99,7 +98,6 @@ const nearBibleVerses = computed(() => {
         verseLineup.push(allChapterVerses.value?.[n])
       }
     })
-    console.log("triggered", verseLineup)
 
     return verseLineup
   }

--- a/components/PreviewVerses.vue
+++ b/components/PreviewVerses.vue
@@ -57,20 +57,7 @@ const props = defineProps<{
 }>()
 
 const allChapterVerses = ref<any[]>()
-
-// Return connected Hymn / Song object related
-const relatedData = computed(() => {
-  switch (props.slide?.type) {
-    case slideTypes.hymn:
-      const hymn = useHymn(props.slide?.songId)
-      return hymn
-    case slideTypes.song:
-      const song = useSong(props.slide?.data, 4)
-      return song
-  }
-  return {}
-})
-
+const relatedData = ref<any>({})
 const bibleChapter = computed(() => props.verse?.split(":")?.[0])
 
 const getAllChapterVerses = async () => {
@@ -78,10 +65,32 @@ const getAllChapterVerses = async () => {
   allChapterVerses.value = chapter?.content
 }
 
+// Return connected Hymn / Song object related
+const getSongOrHymnObj = async () => {
+  switch (props.slide?.type) {
+    case slideTypes.hymn:
+      const hymn = await useHymn(props.slide?.songId)
+      relatedData.value = hymn
+      break
+    case slideTypes.song:
+      const song = useSong(props.slide?.data, 4)
+      relatedData.value = song
+      break
+  }
+}
+
 watch(
   bibleChapter,
   () => {
     getAllChapterVerses()
+  },
+  { immediate: true }
+)
+
+watch(
+  () => props.slide,
+  () => {
+    getSongOrHymnObj()
   },
   { immediate: true }
 )

--- a/components/PreviewVerses.vue
+++ b/components/PreviewVerses.vue
@@ -56,6 +56,8 @@ const props = defineProps<{
   verse: string
 }>()
 
+const allChapterVerses = ref<any[]>()
+
 // Return connected Hymn / Song object related
 const relatedData = computed(() => {
   switch (props.slide?.type) {
@@ -71,10 +73,19 @@ const relatedData = computed(() => {
 
 const bibleChapter = computed(() => props.verse?.split(":")?.[0])
 
-const allChapterVerses = () => {
-  const chapter = useScriptureChapter(props.verse)
-  return chapter?.content
+const getAllChapterVerses = async () => {
+  const chapter = await useScriptureChapter(props.verse)
+  allChapterVerses.value = chapter?.content
 }
+
+watch(
+  bibleChapter,
+  () => {
+    console.log("updated bible chapter")
+    getAllChapterVerses()
+  },
+  { immediate: true }
+)
 
 // Return bible verses in proximity to currentVerse
 const nearBibleVerses = computed(() => {
@@ -82,13 +93,13 @@ const nearBibleVerses = computed(() => {
     const verseLineup: Scripture[] = []
     const currentVerse = Number(props.verse?.split(":")?.[1])
     const verseNumbers = getNumberRange(currentVerse)
-    const chapterVerses = allChapterVerses()
 
     verseNumbers?.forEach((n) => {
-      if (chapterVerses?.[n]) {
-        verseLineup.push(chapterVerses?.[n])
+      if (allChapterVerses.value?.[n]) {
+        verseLineup.push(allChapterVerses.value?.[n])
       }
     })
+    console.log("triggered", verseLineup)
 
     return verseLineup
   }

--- a/components/QuickActions.vue
+++ b/components/QuickActions.vue
@@ -96,6 +96,9 @@
 
       <!-- LIBRARY SECTION-->
       <AddAlert v-else-if="page === 'alert'" @close="page = ''" />
+
+      <!-- COUNTDOWN SECTION-->
+      <AddCountdown v-else-if="page === 'countdown'" @close="page = ''" />
     </Transition>
   </AppSection>
 </template>
@@ -201,6 +204,10 @@ emitter.on("remove-alert", () => {
 emitter.on("add-song", () => {
   libraryPage.value = "add-song"
   page.value = "library"
+})
+
+emitter.on("new-countdown", () => {
+  page.value = "countdown"
 })
 
 onMounted(() => {

--- a/components/QuickActions.vue
+++ b/components/QuickActions.vue
@@ -194,7 +194,7 @@ emitter.on("new-alert", () => {
 })
 
 emitter.on("remove-alert", () => {
-  appStore.setAlert(null)
+  appStore.setActiveAlert(null)
   useToast().add({
     icon: "i-bx-trash",
     title: "Active alert has been removed",

--- a/components/QuickActions.vue
+++ b/components/QuickActions.vue
@@ -72,6 +72,13 @@
       </div>
 
       <!-- SONG SECTION -->
+      <BibleList
+        v-else-if="page === 'bible'"
+        :query="bibleSearchQuery"
+        @close="page = ''"
+      />
+
+      <!-- SONG SECTION -->
       <SongsList
         v-else-if="page === 'song'"
         :query="songSearchQuery"
@@ -117,8 +124,9 @@ const focusedActionIndex = ref<number>(0)
 const actions = ref<any[]>([])
 const quickActions = ref<HTMLDivElement | null>(null)
 const appStore = useAppStore()
-const page = ref<string>("") // song, search
+const page = ref<string>("") // song, search, bible, hymn...
 const songSearchQuery = ref<string>("")
+const bibleSearchQuery = ref<string>("")
 const hymns = ref<Hymn[]>([])
 const emitter = useNuxtApp().$emitter as Emitter<any>
 const libraryPage = ref<string>("")
@@ -157,6 +165,22 @@ const getAllHymns = async () => {
 }
 
 getAllHymns()
+
+watch(page, () => {
+  if (page.value === "") {
+    bibleSearchQuery.value = ""
+  }
+})
+
+emitter.on("new-bible", (data) => {
+  if (data === "") {
+    page.value = "bible"
+  }
+})
+
+emitter.on("bible-search-demo", () => {
+  bibleSearchQuery.value = "Gen 1:1"
+})
 
 emitter.on("new-song", ({ fromSaved }) => {
   if (!fromSaved) {

--- a/components/SearchBibleList.vue
+++ b/components/SearchBibleList.vue
@@ -31,6 +31,7 @@
           :key="`verse ${index}`"
           :action="turnToBibleTypeAction(verse)"
           type="bible"
+          action-suffix="whole-search"
           :class="{
             'bg-primary-50 dark:bg-primary-800 rounded-md':
               index === focusedActionIndex,

--- a/components/SearchBibleList.vue
+++ b/components/SearchBibleList.vue
@@ -45,8 +45,9 @@
 import type { QuickAction, BibleVerse } from "~/types"
 import { useDebounceFn } from "@vueuse/core"
 import fuzzysort from "fuzzysort"
+const db = useIndexedDB()
 
-const kjvBible = useNuxtApp().$kjvBible as BibleVerse[]
+const kjvBible = ref<BibleVerse[]>([])
 const searchInput = ref<string>("")
 const loading = ref<boolean>(false)
 const verses = ref<BibleVerse[]>()
@@ -67,6 +68,12 @@ const turnToBibleTypeAction = (bibleVerse: BibleVerse) => {
     type: slideTypes.bible,
     bibleChapterAndVerse,
   }
+}
+
+const getBible = async () => {
+  const bible = await db.bibleAndHymns.get("KJV")
+  kjvBible.value = bible?.data as unknown as BibleVerse[]
+  getVerses()
 }
 
 onMounted(() => {
@@ -100,19 +107,19 @@ onMounted(() => {
 const getVerses = (query: string = "") => {
   if (query?.length >= 2) {
     loading.value = true
-    let results = fuzzysort.go(query, kjvBible, {
+    let results = fuzzysort.go(query, kjvBible.value, {
       keys: ["scripture"],
     })
     results = results?.map((result) => result.obj) as BibleVerse[]
     verses.value = results.slice(0, 15)
   } else {
     const rand = Math.floor(Math.random() * 1115 + 15)
-    verses.value = kjvBible.slice(rand - 15, rand)
+    verses.value = kjvBible.value.slice(rand - 15, rand)
   }
   loading.value = false
 }
 
-getVerses()
+getBible()
 
 const onSearchInput = useDebounceFn(async () => {
   getVerses(searchInput.value)

--- a/components/SlideChip.vue
+++ b/components/SlideChip.vue
@@ -4,13 +4,14 @@
     :class="[getBGBySlideType(slideType)]"
   >
     <IconWrapper :name="getIconBySlideType(slideType)" size="4" />
-    {{ slideType }}
+    {{ slideType }} {{ slideSubType ? ` (${slideSubType})` : "" }}
   </p>
 </template>
 
 <script setup>
 const props = defineProps({
   slideType: String,
+  slideSubType: String,
   darkMode: Boolean,
 })
 const getIconBySlideType = (slideType) => {

--- a/components/SlideChip.vue
+++ b/components/SlideChip.vue
@@ -30,6 +30,8 @@ const getIconBySlideType = (slideType) => {
       return "i-bx-image"
     case slideTypes.carousel:
       return "i-bx-carousel"
+    case slideTypes.countdown:
+      return "i-bx-time"
   }
   return ""
 }
@@ -60,6 +62,11 @@ const getBGBySlideType = (slideType) => {
         return "bg-orange-700 text-orange-100"
       }
       return "bg-orange-100 border border-orange-500 text-orange-700"
+    case slideTypes.countdown:
+      if (props.darkMode) {
+        return "bg-gray-700 text-gray-100"
+      }
+      return "bg-gray-100 border border-gray-500 text-gray-700"
   }
   return ""
 }

--- a/components/SlideContentByLayout.vue
+++ b/components/SlideContentByLayout.vue
@@ -63,6 +63,21 @@
       v-html="slide?.contents?.[1]"
     ></div>
   </div>
+  <div
+    v-else-if="slide?.layout === slideLayoutTypes.countdown"
+    class="slide-layout-ctn flex flex-col gap-2 h-[100%] justify-center"
+    :style="`padding: ${padding || 0}vw; font-size: ${
+      (slide?.slideStyle?.fontSize!!) *
+      ((slide?.slideStyle?.fontSizePercent || 100) / 100)
+    }vw`"
+  >
+    <div class="content jost" v-html="slide?.contents?.[0]"></div>
+    <div
+      class="content"
+      :class="[useURLFriendlyString(slide?.slideStyle?.font || 'Inter')]"
+      v-html="slide?.contents?.[1]"
+    ></div>
+  </div>
 </template>
 
 <script setup lang="ts">

--- a/components/SlideContentToolbar.vue
+++ b/components/SlideContentToolbar.vue
@@ -50,7 +50,9 @@
     <!-- VIDEO MEDIA SLIDE OPTIONS -->
     <template
       v-if="
-        slide?.type === slideTypes.media && slide?.data?.type?.includes('video')
+        slide?.type === slideTypes.media &&
+        (slide?.data?.type?.includes('video') ||
+          slide?.data?.type?.includes('audio'))
       "
     >
       <UTooltip text="Mute/Unmute media" :popper="{ placement: 'top' }">

--- a/components/SlideContentToolbar.vue
+++ b/components/SlideContentToolbar.vue
@@ -178,6 +178,35 @@
         />
       </UTooltip>
     </div>
+    <!-- COUNTDOWN SLIDE CONTROLS -->
+    <div
+      v-if="slide?.type === slideTypes.countdown"
+      class="button-group bg-primary-100 dark:bg-primary-900 rounded-md mx-1 p-1 h-[36px] mt-[2px] flex items-center gap-1"
+    >
+      <UTooltip text="Start/pause countdown" :popper="{ placement: 'top' }">
+        <UButton
+          @click="useGlobalEmit('start-countdown', slide)"
+          :class="[
+            'dark:text-primary-500 dark:hover:text-primary-500 p-2 hover:bg-primary-300 hover:text-primary-500',
+          ]"
+          variant="ghost"
+        >
+          <IconWrapper size="5" name="i-tabler-play" />
+          /
+          <IconWrapper size="5" name="i-tabler-pause" />
+        </UButton>
+      </UTooltip>
+      <UTooltip text="Restart countdown" :popper="{ placement: 'top' }">
+        <UButton
+          @click="useGlobalEmit('restart-countdown', slide)"
+          :class="[
+            'dark:text-primary-500 dark:hover:text-primary-500 p-2 hover:bg-primary-300 hover:text-primary-500',
+          ]"
+          icon="i-tabler-refresh"
+          variant="ghost"
+        />
+      </UTooltip>
+    </div>
     <div
       v-if="slide?.type !== slideTypes?.media"
       class="button-group rounded-md p-1 flex items-center gap-1"

--- a/components/SongsList.vue
+++ b/components/SongsList.vue
@@ -3,7 +3,7 @@
     <div class="flex gap-2">
       <UInput
         icon="i-bx-search"
-        placeholder="Search song titles"
+        placeholder="Search scripture"
         v-model="searchInput"
         class="w-[100%]"
         @input="onSearchInput"

--- a/components/TipTap.client.vue
+++ b/components/TipTap.client.vue
@@ -49,6 +49,21 @@
     />
     <TiptapEditorContent :editor="uneditableEditorTwo" />
   </div>
+  <div
+    v-else-if="slide?.layout === slideLayoutTypes.countdown"
+    class="slide-layout-ctn flex flex-col gap-2 h-[100%] justify-center rounded-md px-12"
+    :class="{
+      'center-live-content': slide?.slideStyle?.alignment === 'center',
+      'left-live-content': slide?.slideStyle?.alignment === 'left',
+      'right-live-content': slide?.slideStyle?.alignment === 'right',
+    }"
+  >
+    <TiptapEditorContent :editor="uneditableEditorOne" class="jost" />
+    <TiptapEditorContent
+      :editor="uneditableEditorTwo"
+      :class="useURLFriendlyString(slide?.slideStyle?.font || '')"
+    />
+  </div>
 </template>
 
 <script setup lang="ts">

--- a/composables/useBackgroundVideos.ts
+++ b/composables/useBackgroundVideos.ts
@@ -4,7 +4,8 @@ const useBackgroundVideos = async (id?: string) => {
     const video = await db.cached.get(id)
     return video?.data
   } else {
-    const allVideos = await db.cached.toArray()
+    let allVideos = await db.cached.toArray()
+    allVideos = allVideos?.filter(video => video.data?.type?.includes('video'))
     return allVideos.map(video => video?.data)
   }
 }

--- a/composables/useBackgroundVideos.ts
+++ b/composables/useBackgroundVideos.ts
@@ -5,7 +5,7 @@ const useBackgroundVideos = async (id?: string) => {
     return video?.data
   } else {
     let allVideos = await db.cached.toArray()
-    allVideos = allVideos?.filter(video => video.data?.type?.includes('video'))
+    allVideos = allVideos?.filter(video => video.data?.type?.includes('video') && !video?.id?.includes('custom'))
     return allVideos.map(video => video?.data)
   }
 }

--- a/composables/useHymn.ts
+++ b/composables/useHymn.ts
@@ -1,8 +1,9 @@
-import { Hymn } from '~/types'
+import type { Hymn } from '~/types'
 
-const useHymn = (number: string): Hymn | null => {
-  const nuxtApp = useNuxtApp()
-  const hymns = nuxtApp.$hymns as Array<Hymn>
+const useHymn = async (number: string): Promise<Hymn | null> => {
+  const db = useIndexedDB()
+  let hymns: any = await db.bibleAndHymns.get('hymns')
+  hymns = hymns?.data as unknown as Hymn[]
   const toast = useToast()
 
   try {

--- a/composables/useIndexedDB.ts
+++ b/composables/useIndexedDB.ts
@@ -16,6 +16,7 @@ class WorshipCloudDatabase extends Dexie {
   public media!: Table<Media>
   public library!: Table<LibraryItem, string>
   public cached!: Table<Media>
+  public bibleAndHymns!: Table<Media>
 
   public constructor() {
     super('WorshipCloudDatabase')
@@ -23,7 +24,8 @@ class WorshipCloudDatabase extends Dexie {
       songs: 'id,lyrics,title,album,cover,artist,verses,createdAt,updatedAt',
       media: 'id,content,data,createdAt,updatedAt', // id === slide.id
       library: 'id,type,content,createdAt,updatedAt',
-      cached: 'id,content,data,createdAt,updatedAt'
+      cached: 'id,content,data,createdAt,updatedAt',
+      bibleAndHymns: 'id,data,createdAt,updatedAt'
     })
   }
 

--- a/composables/useMilliToTimeString.ts
+++ b/composables/useMilliToTimeString.ts
@@ -1,0 +1,18 @@
+
+
+const useMilliToTimeString = (milliseconds: number) => {
+  // Calculate hours, minutes, and seconds
+  const hours = Math.floor(milliseconds / (1000 * 60 * 60));
+  const minutes = Math.floor((milliseconds % (1000 * 60 * 60)) / (1000 * 60));
+  const seconds = Math.floor((milliseconds % (1000 * 60)) / 1000);
+
+  // Pad the hours, minutes, and seconds with leading zeros if necessary
+  const paddedHours = String(hours).padStart(2, '0');
+  const paddedMinutes = String(minutes).padStart(2, '0');
+  const paddedSeconds = String(seconds).padStart(2, '0');
+
+  // Return the time string in HH:MM:SS format
+  return `${paddedHours}:${paddedMinutes}:${paddedSeconds}`;
+}
+
+export default useMilliToTimeString

--- a/composables/useS3File.ts
+++ b/composables/useS3File.ts
@@ -5,15 +5,15 @@ const useS3File = async (fileName: string) => {
   const runtimeConfig = useRuntimeConfig()
 
   const client = new S3Client({
-    region: runtimeConfig.public.CLOUD_AWS_BUCKET_REGION,
+    region: runtimeConfig.public.AWS_BUCKET_REGION,
     credentials: {
-      accessKeyId: runtimeConfig.public.CLOUD_AWS_ACCESS_KEY_ID,
-      secretAccessKey: runtimeConfig.public.CLOUD_AWS_SECRET_ACCESS_KEY
+      accessKeyId: runtimeConfig.public.AWS_ACCESS_KEY_ID,
+      secretAccessKey: runtimeConfig.public.AWS_SECRET_ACCESS_KEY
     }
   })
 
   const command = new GetObjectCommand({
-    Bucket: runtimeConfig.public.CLOUD_AWS_BUCKET_NAME,
+    Bucket: runtimeConfig.public.AWS_BUCKET_NAME,
     Key: fileName
   })
 

--- a/composables/useScreenFontSize.ts
+++ b/composables/useScreenFontSize.ts
@@ -22,10 +22,10 @@ const useScreenFontSize = (content: string, fontSizePercent: number = 100) => {
    * where 525 is the highest content length and 4.8vw is the corresponding font size
    * and 125 is the lowest content length and 2.8vw is the corresponding font size
    */
-  let contentLength = content.length
+  let contentLength = content?.length
   const regex = /\n/g
   let newLineCharacters =
-    [...content.matchAll(regex)].length
+    [...content.matchAll(regex)]?.length
   contentLength += (newLineCharacters * 25)
   const fontSize = 4.9 + (contentLength - 125) * (2.8 - 5) / (525 - 125)
   let percentageIncrease = fontSizePercent / 100

--- a/composables/useScripture.ts
+++ b/composables/useScripture.ts
@@ -1,12 +1,8 @@
 import { useAppStore } from '~/store/app'
-import { Scripture } from '~/types'
+import { BibleVerse, Scripture } from '~/types'
 
-const useScripture = (label: string = '1:1:1', version: string = ''): Scripture | null => {
-  const nuxtApp = useNuxtApp()
-  const kjvBible = nuxtApp.$kjvBible
-  const nkjvBible = nuxtApp.$nkjvBible
-  const nivBible = nuxtApp.$nivBible
-  const ampBible = nuxtApp.$ampBible
+const useScripture = async (label: string = '1:1:1', version: string = ''): Promise<Scripture | null> => {
+  const db = useIndexedDB()
 
   // set default version
   const appStore = useAppStore()
@@ -23,18 +19,22 @@ const useScripture = (label: string = '1:1:1', version: string = ''): Scripture 
   try {
     switch (version) {
       case 'NKJV':
+        const nkjvBible = (await db.bibleAndHymns.get('NKJV'))?.data as unknown as BibleVerse[]
         scripture = nkjvBible?.find((scripture: any) => Number(scripture.book) === book && Number(scripture.chapter) === chapter && Number(scripture.verse) === verse).scripture
         appStore.setDefaultBibleVersion(version)
         break
       case 'NIV':
+        const nivBible = (await db.bibleAndHymns.get('NIV'))?.data as unknown as BibleVerse[]
         scripture = nivBible?.find((scripture: any) => Number(scripture.book) === book && Number(scripture.chapter) === chapter && Number(scripture.verse) === verse).scripture
         appStore.setDefaultBibleVersion(version)
         break
       case 'AMP':
+        const ampBible = (await db.bibleAndHymns.get('AMP'))?.data as unknown as BibleVerse[]
         scripture = ampBible?.find((scripture: any) => Number(scripture.book) === book && Number(scripture.chapter) === chapter && Number(scripture.verse) === verse).scripture
         appStore.setDefaultBibleVersion(version)
         break
       default:
+        const kjvBible = (await db.bibleAndHymns.get('KJV'))?.data as unknown as BibleVerse[]
         scripture = kjvBible?.find((scripture: any) => Number(scripture.book) === book && Number(scripture.chapter) === chapter && Number(scripture.verse) === verse).scripture
         appStore.setDefaultBibleVersion(version)
         break

--- a/composables/useScriptureChapter.ts
+++ b/composables/useScriptureChapter.ts
@@ -1,12 +1,8 @@
 import { useAppStore } from '~/store/app'
-import { Scripture } from '~/types'
+import type { BibleVerse, Scripture } from '~/types'
 
-const useScriptureChapter = (label: string = '1:1', version: string = ''): Scripture | null => {
-  const nuxtApp = useNuxtApp()
-  const kjvBible = nuxtApp.$kjvBible
-  const nkjvBible = nuxtApp.$nkjvBible
-  const nivBible = nuxtApp.$nivBible
-  const ampBible = nuxtApp.$ampBible
+const useScriptureChapter = async (label: string = '1:1', version: string = ''): Promise<Scripture | null> => {
+  const db = useIndexedDB()
 
   // set default version
   const appStore = useAppStore()
@@ -23,18 +19,22 @@ const useScriptureChapter = (label: string = '1:1', version: string = ''): Scrip
   try {
     switch (version) {
       case 'NKJV':
+        const nkjvBible = (await db.bibleAndHymns.get('NKJV'))?.data as unknown as BibleVerse[]
         verses = nkjvBible?.filter((scripture: any) => Number(scripture.book) === book && Number(scripture.chapter) === chapter)
         appStore.setDefaultBibleVersion(version)
         break
       case 'NIV':
+        const nivBible = (await db.bibleAndHymns.get('NIV'))?.data as unknown as BibleVerse[]
         verses = nivBible?.filter((scripture: any) => Number(scripture.book) === book && Number(scripture.chapter) === chapter)
         appStore.setDefaultBibleVersion(version)
         break
       case 'AMP':
+        const ampBible = (await db.bibleAndHymns.get('AMP'))?.data as unknown as BibleVerse[]
         verses = ampBible?.filter((scripture: any) => Number(scripture.book) === book && Number(scripture.chapter) === chapter)
         appStore.setDefaultBibleVersion(version)
         break
       default:
+        const kjvBible = (await db.bibleAndHymns.get('KJV'))?.data as unknown as BibleVerse[]
         verses = kjvBible?.filter((scripture: any) => Number(scripture.book) === book && Number(scripture.chapter) === chapter)
         appStore.setDefaultBibleVersion(version)
         break

--- a/composables/useScriptureLabel.ts
+++ b/composables/useScriptureLabel.ts
@@ -1,13 +1,21 @@
 /**
- * Function to return scripture in format (book:chapter:verse) from format like (Book chapter:verse)
+ * Function to return scripture in format (book:chapter:verse) from format like (Book chapter:verse) and vice versa
  * @param label 
  * @returns 
  */
-function useScriptureLabel(label: string) {
-  const book = label?.slice(0, label?.lastIndexOf(' '))
-  const bookIndex = bibleBooks.findIndex(bibleBook => bibleBook.toLowerCase() === book.toLowerCase()) + 1
-  const bibleChapterAndVerse = label?.slice(label?.lastIndexOf(' ') + 1)
-  return `${bookIndex}:${bibleChapterAndVerse}`
+function useScriptureLabel(label: string, options: { toLongForm: boolean }) {
+  if (options?.toLongForm) {
+    const book = Number(label?.split(':')?.[0])
+
+    const bibleChapterAndVerse = label?.slice(label?.indexOf(':') + 1)
+    return `${bibleBooks[book - 1]} ${bibleChapterAndVerse}`
+  } else {
+
+    const book = label?.slice(0, label?.lastIndexOf(' '))
+    const bookIndex = bibleBooks.findIndex(bibleBook => bibleBook.toLowerCase() === book.toLowerCase()) + 1
+    const bibleChapterAndVerse = label?.slice(label?.lastIndexOf(' ') + 1)
+    return `${bookIndex}:${bibleChapterAndVerse}`
+  }
 }
 
 export default useScriptureLabel

--- a/composables/useSlideContent.ts
+++ b/composables/useSlideContent.ts
@@ -1,5 +1,5 @@
 import { useAppStore } from "~/store/app"
-import type { Hymn, Scripture, Slide, Song } from "~/types/index"
+import type { Countdown, Hymn, Scripture, Slide, Song } from "~/types/index"
 
 /**
  * 
@@ -8,7 +8,7 @@ import type { Hymn, Scripture, Slide, Song } from "~/types/index"
  * @param nextVerse 
  * @returns 
  */
-const useSlideContent = (slide: Slide, data: Scripture | Hymn | Song, nextVerse: string = '') => {
+const useSlideContent = (slide: Slide, data: Scripture | Hymn | Song | Countdown, nextVerse: string = '') => {
   const appStore = useAppStore()
 
   // Remove unwanted sequences from string
@@ -34,6 +34,13 @@ const useSlideContent = (slide: Slide, data: Scripture | Hymn | Song, nextVerse:
       return [
         `<p class="song-content">${nextVerse?.replaceAll("\n", '<br class="mt-3">')}</>`,
         `<p class="song-label"><b>${data?.title}</b> • ${data.artist}</p>`,
+      ]
+    case slideTypes.countdown:
+      data = data as Countdown
+      return [
+        `<p class="countdown-label" style="line-height: 0;">${data?.content}</p>`,
+        `<p class="countdown-content opacity-75 leading-[1]">${data?.timeLeft?.replace('00:', '')}</>`,
+        // <p class="copyright-content">${appStore.copyrightContent[data?.version]}</p>`,
       ]
   }
 

--- a/composables/useSlideName.ts
+++ b/composables/useSlideName.ts
@@ -14,6 +14,8 @@ const useSlideName = (slide: Slide) => {
       return slide.contents?.[1]?.trim()?.replaceAll('<br>', '\n')?.replaceAll('</h1>', '\n')?.replaceAll('</h2>', '\n')?.replaceAll('</h3>', '\n')?.replace(/<[^>]*>/g, '')?.split('\n')?.[0]
     case slideTypes.hymn:
       return `Hymn ${slide?.songId}`
+    case slideTypes.countdown:
+      return slide?.data?.time?.replace('00:', '')
     default:
       return `${slide?.title}`
   }

--- a/composables/useTimeStringToMilli.ts
+++ b/composables/useTimeStringToMilli.ts
@@ -1,0 +1,8 @@
+const useTimeStringToMilli = (timeString: string) => {
+  const [hours, minutes, seconds] = timeString.split(':').map(Number);
+  const milliseconds = (hours * 3600 + minutes * 60 + seconds) * 1000;
+
+  return milliseconds;
+}
+
+export default useTimeStringToMilli

--- a/layouts/app.vue
+++ b/layouts/app.vue
@@ -111,42 +111,56 @@ const saveAllBackgroundVideos = async () => {
   // })
 }
 
+const tempBibleVersion = (version: string, data: any) => ({
+  id: version,
+  data,
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+})
+
 const downloadEssentialResources = async () => {
+  const db = useIndexedDB()
+
   loadingResources.value = true
   downloadProgress.value = 1
 
   // Download KJV Bible
-  if (!useNuxtApp().$kjvBible) {
+  let tempBible = await db.bibleAndHymns.get("KJV")
+  if (!tempBible) {
     const kjvBible = await useS3File("kjv.json")
-    useNuxtApp().provide("kjvBible", kjvBible || "")
+    db.bibleAndHymns.add(tempBibleVersion("KJV", kjvBible))
     downloadProgress.value = 2
   }
 
   // Download NKJV Bible
-  if (!useNuxtApp().$nkjvBible) {
+  tempBible = await db.bibleAndHymns.get("NKJV")
+  if (!tempBible) {
     const nkjvBible = await useS3File("nkjv.json")
-    useNuxtApp().provide("nkjvBible", nkjvBible || "")
+    db.bibleAndHymns.add(tempBibleVersion("NKJV", nkjvBible))
     downloadProgress.value = 3
   }
 
   // Download NIV Bible
-  if (!useNuxtApp().$nivBible) {
+  tempBible = await db.bibleAndHymns.get("NIV")
+  if (!tempBible) {
     const nivBible = await useS3File("niv.json")
-    useNuxtApp().provide("nivBible", nivBible || "")
+    db.bibleAndHymns.add(tempBibleVersion("NIV", nivBible))
     downloadProgress.value = 4
   }
 
   // Download AMP Bible
-  if (!useNuxtApp().$ampBible) {
+  tempBible = await db.bibleAndHymns.get("AMP")
+  if (!tempBible) {
     const ampBible = await useS3File("amp.json")
-    useNuxtApp().provide("ampBible", ampBible || "")
+    db.bibleAndHymns.add(tempBibleVersion("AMP", ampBible))
     downloadProgress.value = 5
   }
 
   // Download all hymns
-  if (!useNuxtApp().$hymns) {
+  tempBible = await db.bibleAndHymns.get("hymns")
+  if (!tempBible) {
     const hymns = await useS3File("hymns.json")
-    useNuxtApp().provide("hymns", hymns || "")
+    db.bibleAndHymns.add(tempBibleVersion("hymns", hymns))
     downloadProgress.value = 6
   }
 

--- a/layouts/app.vue
+++ b/layouts/app.vue
@@ -258,6 +258,21 @@ const retrieveAllMediaFilesFromDB = async () => {
         }
         appStore.setActiveSlides(slides)
       }
+    } else {
+      // console.log(slide.name, slide.backgroundVideoKey)
+      // console.log(slide.name, slide.background)
+      if (slide?.backgroundVideoKey) {
+        const cachedBackgroundVideo = await db.cached.get(
+          slide?.backgroundVideoKey
+        )
+        // console.log(cachedBackgroundVideo)
+        const arrayBuffer: ArrayBuffer = cachedBackgroundVideo?.data!!
+        const blob = new Blob([arrayBuffer], {
+          type: cachedBackgroundVideo?.content?.type,
+        })
+        const fileUrl = URL.createObjectURL(blob)
+        slide.background = fileUrl
+      }
     }
   })
 

--- a/layouts/app.vue
+++ b/layouts/app.vue
@@ -253,7 +253,9 @@ const retrieveAllMediaFilesFromDB = async () => {
         })
         const fileUrl = URL.createObjectURL(blob)
         slide.data.url = fileUrl
-        slide.background = fileUrl
+        if (!slide.data?.type?.includes("audio")) {
+          slide.background = fileUrl
+        }
         appStore.setActiveSlides(slides)
       }
     }

--- a/store/app.ts
+++ b/store/app.ts
@@ -32,7 +32,8 @@ export const useAppStore = defineStore('app', {
         slideStyles: { blur: 0.5, brightness: 50 } as SlideStyle
       },
       backgroundVideos: [] as string[],
-      alert: null as Alert | null,
+      alerts: [] as Alert[],
+      activeAlert: null as Alert | null,
       copyrightContent: {
         'KJV': '',
         'NKJV': 'Scripture taken from the New King James Version®. Copyright © 1982 by Thomas Nelson. All rights reserved.',
@@ -70,8 +71,11 @@ export const useAppStore = defineStore('app', {
     setDefaultFont(font: string) {
       this.settings = { ...this.settings, defaultFont: font }
     },
-    setAlert(alert: Alert | null) {
-      this.alert = alert
+    setAlerts(alerts: Alert[]) {
+      this.alerts = alerts
+    },
+    setActiveAlert(alert: Alert | null) {
+      this.activeAlert = alert
     },
     setBackgroundVideos(bgVideos: string[]) {
       this.backgroundVideos = bgVideos

--- a/store/app.ts
+++ b/store/app.ts
@@ -39,7 +39,8 @@ export const useAppStore = defineStore('app', {
         'NKJV': 'Scripture taken from the New King James Version®. Copyright © 1982 by Thomas Nelson. All rights reserved.',
         'NIV': 'Scriptures taken from the Holy Bible, New International Version®, NIV®. Copyright © 1973, 1978, 1984, 2011 by Biblica, Inc.™ All rights reserved worldwide.',
         'AMP': 'All Scripture quotations, unless otherwise indicated, are taken from the Amplified Bible, Copyright © 2015 by The Lockman Foundation.'
-      }
+      },
+      recentBibleSearches: [] as string[]
     }
   },
   actions: {
@@ -82,6 +83,16 @@ export const useAppStore = defineStore('app', {
       this.settings.defaultBackground.hymn.background = bgVideos?.[0]
       this.settings.defaultBackground.bible.background = bgVideos?.[2]
       this.settings.defaultBackground.text.background = bgVideos?.[3]
+    },
+    setRecentBibleSearches(searchQuery: string) {
+      let tempArr = [...this.recentBibleSearches]
+      if (this.recentBibleSearches.length >= 20) {
+        tempArr.shift()
+        this.recentBibleSearches = tempArr
+      }
+      const tempSet = new Set(tempArr)
+      tempSet.add(searchQuery)
+      this.recentBibleSearches = Array.from(tempSet).reverse()
     }
   },
   persist: {

--- a/types/index.ts
+++ b/types/index.ts
@@ -79,6 +79,9 @@ export interface Song {
   cover?: string
   author?: string
   verses?: Array<string>
+  isPublic?: boolean
+  createdBy?: string
+  churchId?: string
   createdAt?: string
   updatedAt?: string
 }

--- a/types/index.ts
+++ b/types/index.ts
@@ -10,7 +10,7 @@ export interface Slide {
   title?: string // For hymn and song titles, also for scripture labels (e.g Ephesians 3:1)
   songId?: string // only for hymns/songs, could be [hymn.number] or [song.id]
   hasChorus?: boolean // only for hymns, to tell if the hymns include a chorus
-  data?: Song | Scripture | Hymn // for song/bible/hymn/file, Object mapped to Slide only on client
+  data?: Song | Scripture | Hymn | Countdown // for song/bible/hymn/file, Object mapped to Slide only on client
   slideStyle?: SlideStyle,
   createdAt?: string,
   updatedAt?: string
@@ -23,6 +23,14 @@ export interface Alert {
   style: string
   background: string
   // position: string // top, bottom
+}
+
+export interface Countdown {
+  id: string
+  time: string
+  timeLeft: string
+  content: string
+  // style: string
 }
 
 export interface QuickAction {
@@ -100,7 +108,7 @@ export interface SlideStyle {
   fontSizePercent?: number
   backgroundFillType?: string
   repeatMedia?: boolean
-  isMediaPlaying?: boolean
+  isMediaPlaying?: boolean // also used to check if countdown is paused or is beginning
   mediaSeekPosition?: number // 0 or -1, -1 means not at the beginning
   isMediaMuted?: boolean
 }

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -6,6 +6,7 @@ export const slideTypes = {
   media: 'media',
   sermon: 'sermon',
   carousel: 'carousel',
+  countdown: 'countdown',
 }
 
 export const libraryTypes = {
@@ -106,11 +107,11 @@ export const quickActionsArr = [
   {
     icon: "i-bx-time",
     name: "Add Countdown Timer",
-    desc: "Find scriptures with familiar words",
-    action: "new-timer",
+    desc: "Engage your church with countdown",
+    action: "new-countdown",
     meta: "",
-    unreleased: true,
-    type: slideTypes.text,
+    type: slideTypes.countdown,
+    // unreleased: true,
   },
   {
     icon: "i-ph-file-ppt",
@@ -155,6 +156,7 @@ export const slideLayoutTypes = {
   full_text: 'full-text',
   two_column: 'two-column',
   bible: 'bible',
+  countdown: 'countdown',
   empty: 'empty',
 }
 

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -60,7 +60,7 @@ export const quickActionsArr = [
   {
     icon: "i-bx-image",
     name: "Add Media",
-    desc: "Display video or image media",
+    desc: "Display image, video or audio media",
     action: "new-media",
     meta: "",
     type: slideTypes.media,


### PR DESCRIPTION
- You can now add your own images and videos as backgrounds for your slides.
- We've added support for your audio-only files for media slides. Just go ahead and create a media slide and see the customizations you can add to your media(audio) slide.
- You can now play, pause and restart your media files with the Media slide controls.
- One alert is not enough, we added an alert scheduler so you can store alerts and take any one live as you wish.
- This one is exciting! We added a countdown timer for your convenience. Now you can let your congregation know what how soon an event starts or finish in an exciting manner.
- Sharing is caring; now other people can use the songs you upload—but only if you want.
- We don't want you to ever make a mistake taking slides LIVE. So we added a two-step feature to the "Display Bible" action on the quick actions pane.
- Want to edit a live slide quickly, double tap the slide in the Live Output pane and make your quick adjustments ;)`