### PR TITLE
feat: v0.9.1/one account per user, flickering backdrop, improved app-wide settings, and more!

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -39,7 +39,7 @@ const appStore = useAppStore()
 nuxtApp.provide("emitter", emitter)
 appStore.setEmitter(emitter)
 
-const appVersion = ref<string>("0.9.0")
+const appVersion = ref<string>("0.9.1")
 
 // const registerServiceWorker = async () => {
 //   if ("serviceWorker" in navigator) {

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -257,6 +257,16 @@ body {
   animation: come-up 0.6s ease-in-out forwards;
   -webkit-animation: come-up 0.6s ease-in-out forwards;
 }
+.no-animations {
+  .come-up-1 {
+    animation: none;
+    -webkit-animation: none;
+  }
+  .come-up-2 {
+    animation: none;
+    -webkit-animation: none;
+  }
+}
 
 @keyframes come-up {
   0% {

--- a/components/BibleVersionSettings.vue
+++ b/components/BibleVersionSettings.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="h-[62.5vh] overflow-y-auto mb-[2.5%]">
+  <div class="h-[100%] overflow-y-auto mb-[2.5%]">
     <div
       v-for="bibleVersion in bibleVersionOptions"
       :key="bibleVersion"

--- a/components/ChangelogModal.vue
+++ b/components/ChangelogModal.vue
@@ -44,6 +44,7 @@
 </template>
 
 <script setup lang="ts">
+import { settings } from "firebase/analytics"
 import type { Emitter } from "mitt"
 import { useAppStore } from "~/store/app"
 import type { Church, User } from "~/store/auth"
@@ -58,18 +59,18 @@ defineProps<{
 }>()
 
 const emitter = useNuxtApp().$emitter as Emitter<any>
-const changelog = `- Introduced a live alert indicator on the control screen.
-- Added a shortcuts panel with new hotkeys for next, previous, search, and more actions.
-- Implemented undo/redo for slides with initial issues now resolved through refinements.
-- Resolved unnecessary redirects during church registration.
-- Fixed issues affecting the live page functionality.
-- Addressed a bug when saving slides with uploaded images.
-- Enhanced the search shortcut and resolved related issues.
-- Removed loggers and performed additional clean-up tasks.
-- Connected the app info endpoint and fixed breaking changes.
-- Expanded the app with new Bible versions.
-- Made improvements to force an update page when needed.
-- Refreshed and modified the Cloud of Worship page content.`
+const changelog = `- Switched to NuxtHub for better uptime in Nigeria region.
+- Enforced one church account per user.
+- Fixed flickering backdrop issue on slide change.
+- Added animation settings for slides.
+- Added app-wide setting for number of lines per slide.
+- Added storage settings, indicator including local data deletion.
+- Fixed an issue affecting offline access functionality.
+- Refined display and screen settings, including media slide background and content background fill type on Edit Content Pane.
+- Resolved an issue with a wrong error message on the /verify page.
+- Fixed a bug causing perpetual slide retrieval on schedule change.
+- Updated Bible versions download process and improved sensitive information handling.
+- Implemented auto-redirect to home page upon app update.`
 
 const appStore = useAppStore()
 

--- a/components/DisplaySettings.vue
+++ b/components/DisplaySettings.vue
@@ -1,5 +1,7 @@
 <template>
-  <div class="settings-ctn h-[100%] flex flex-col gap-6">
+  <div
+    class="settings-ctn h-[100%] flex flex-col gap-6 overflow-y-auto mb-[2.5%] pb-[10%]"
+  >
     <div v-if="currentScreen" class="primary-display flex flex-col gap-2">
       <div class="sub-header">
         <h3 class="font-medium">Control Center</h3>

--- a/components/DisplaySettings.vue
+++ b/components/DisplaySettings.vue
@@ -1,0 +1,98 @@
+<template>
+  <div class="settings-ctn h-[100%] flex flex-col gap-6">
+    <div v-if="currentScreen" class="primary-display flex flex-col gap-2">
+      <h3 class="font-medium">Primary Screen (Control Center)</h3>
+      <div
+        class="bg-primary-100 p-4 px-6 rounded-md flex justify-between items-center"
+      >
+        <div class="info flex gap-4">
+          <IconWrapper name="i-lucide-monitor" size="6" class="pt-1" />
+          <div class="name-and-dimensions">
+            <div class="name text-sm font-semibold">
+              {{ currentScreen?.label }}
+            </div>
+            <div class="dimensions text-xs">
+              {{ currentScreen?.width }} x
+              {{ currentScreen?.height }}
+            </div>
+          </div>
+        </div>
+        <UButton
+          v-if="!currentScreen?.isInternal"
+          @click="moveCurrentScreenToNativeDisplay"
+        >
+          Move to native screen
+        </UButton>
+      </div>
+    </div>
+    <div
+      v-if="allScreens?.length"
+      class="secondary-display flex flex-col gap-2"
+    >
+      <h3 class="font-medium">All Screens</h3>
+      <div
+        v-for="screen in allScreens?.filter((screen: any) => screen?.label !== currentScreen?.label)"
+        :key="screen.label"
+        class="bg-gray-100 p-4 px-6 rounded-md flex justify-between items-center"
+      >
+        <div class="info flex gap-4">
+          <IconWrapper name="i-lucide-monitor-play" size="6" class="pt-1" />
+          <div class="name-and-dimensions">
+            <div class="name text-sm font-semibold">
+              {{ screen?.label }}
+            </div>
+            <div class="dimensions text-xs">
+              {{ screen?.width }} x
+              {{ screen?.height }}
+            </div>
+          </div>
+        </div>
+
+        <div
+          v-if="currentScreen.label !== screen.label"
+          class="flex flex-col gap-2"
+        >
+          <!-- <div>Live content screen:</div> -->
+          <UCheckbox
+            :ui="{ base: 'h-5 w-5' }"
+            label="Main display"
+            :value="screen.label"
+            :model-value="currentState.mainDisplayLabel === screen.label"
+            @change="appStore.setMainDisplayLabel($event ? screen.label : '')"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useAppStore } from "@/store/app"
+
+const appStore = useAppStore()
+const currentScreen = ref<any>({})
+const allScreens = ref<any>([])
+const { currentState } = storeToRefs(appStore)
+
+let screenDetails: any
+
+onMounted(async () => {
+  screenDetails = await window.getScreenDetails()
+  currentScreen.value = screenDetails?.currentScreen
+  allScreens.value = screenDetails?.screens
+
+  addEventListener("resize", async () => {
+    screenDetails = await window.getScreenDetails()
+    currentScreen.value = screenDetails.currentScreen
+  })
+})
+
+const moveCurrentScreenToNativeDisplay = async () => {
+  const nativeDisplay = allScreens.value.find(
+    (screen: any) => screen?.isInternal
+  )
+  document.documentElement.requestFullscreen({
+    screen: nativeDisplay,
+  })
+}
+</script>

--- a/components/DisplaySettings.vue
+++ b/components/DisplaySettings.vue
@@ -1,15 +1,26 @@
 <template>
   <div class="settings-ctn h-[100%] flex flex-col gap-6">
     <div v-if="currentScreen" class="primary-display flex flex-col gap-2">
-      <h3 class="font-medium">Primary Screen (Control Center)</h3>
+      <div class="sub-header">
+        <h3 class="font-medium">Control Center</h3>
+        <p class="text-xs opacity-50 mb-2 mt-1">
+          This is where behind the scene control is done. We advise you get a
+          second screen for the live content.
+        </p>
+      </div>
       <div
-        class="bg-primary-100 p-4 px-6 rounded-md flex justify-between items-center"
+        class="bg-primary-100 dark:bg-primary-800 p-4 px-6 rounded-md flex justify-between items-center"
       >
         <div class="info flex gap-4">
           <IconWrapper name="i-lucide-monitor" size="6" class="pt-1" />
           <div class="name-and-dimensions">
             <div class="name text-sm font-semibold">
               {{ currentScreen?.label }}
+              <span
+                v-if="currentScreen?.isPrimary"
+                class="internal bg-primary-300 dark:bg-primary-600 text-xs px-2 py-1 rounded-md ml-1"
+                >Primary screen</span
+              >
             </div>
             <div class="dimensions text-xs">
               {{ currentScreen?.width }} x
@@ -18,10 +29,12 @@
           </div>
         </div>
         <UButton
-          v-if="!currentScreen?.isInternal"
+          v-if="!currentScreen?.isPrimary"
+          variant="ghost"
+          leading-icon="i-bx-info-circle"
           @click="moveCurrentScreenToNativeDisplay"
         >
-          Move to native screen
+          Move this window to primary screen
         </UButton>
       </div>
     </div>
@@ -29,17 +42,39 @@
       v-if="allScreens?.length"
       class="secondary-display flex flex-col gap-2"
     >
-      <h3 class="font-medium">All Screens</h3>
+      <div class="flex items-center justify-between">
+        <h3 class="font-medium">Secondary Screens</h3>
+        <UButton
+          size="sm"
+          variant="outline"
+          leading-icon="i-bx-refresh"
+          :loading="isLoading"
+          @click="getDisplayDetails()"
+        >
+          Refresh screens
+        </UButton>
+      </div>
+      <div class="no-screens" v-if="!externalScreens?.length">
+        <div class="text-center max-w-[150px] mx-auto mt-[5%]">
+          <IconWrapper name="i-lucide-monitor-x" size="7" class="pb-2" />
+          <div class="text-sm">No external screens detected</div>
+        </div>
+      </div>
       <div
         v-for="screen in allScreens?.filter((screen: any) => screen?.label !== currentScreen?.label)"
         :key="screen.label"
-        class="bg-gray-100 p-4 px-6 rounded-md flex justify-between items-center"
+        class="bg-gray-100 dark:bg-gray-800 p-4 px-6 rounded-md flex justify-between items-center"
       >
         <div class="info flex gap-4">
           <IconWrapper name="i-lucide-monitor-play" size="6" class="pt-1" />
           <div class="name-and-dimensions">
             <div class="name text-sm font-semibold">
               {{ screen?.label }}
+              <span
+                v-if="screen?.isPrimary"
+                class="internal bg-primary-200 dark:bg-primary-800 text-xs px-2 py-1 rounded-md ml-1"
+                >Primary screen</span
+              >
             </div>
             <div class="dimensions text-xs">
               {{ screen?.width }} x
@@ -54,8 +89,8 @@
         >
           <!-- <div>Live content screen:</div> -->
           <UCheckbox
-            :ui="{ base: 'h-5 w-5' }"
-            label="Main display"
+            :ui="{ base: 'h-5 w-5', rounded: 'rounded-full' }"
+            label="Live display"
             :value="screen.label"
             :model-value="currentState.mainDisplayLabel === screen.label"
             @change="appStore.setMainDisplayLabel($event ? screen.label : '')"
@@ -68,28 +103,51 @@
 
 <script setup lang="ts">
 import { useAppStore } from "@/store/app"
+import { useDebounceFn } from "@vueuse/core"
 
 const appStore = useAppStore()
 const currentScreen = ref<any>({})
 const allScreens = ref<any>([])
 const { currentState } = storeToRefs(appStore)
+const isLoading = ref(false)
 
 let screenDetails: any
 
-onMounted(async () => {
+const externalScreens = computed(() => {
+  return allScreens.value.filter(
+    (screen: any) => screen?.label !== currentScreen.value?.label
+  )
+})
+
+const getDisplayDetails = async () => {
+  isLoading.value = true
   screenDetails = await window.getScreenDetails()
   currentScreen.value = screenDetails?.currentScreen
   allScreens.value = screenDetails?.screens
+  isLoading.value = false
+  useToast().add({
+    title: "Screens updated",
+    icon: "i-bx-check-circle",
+  })
+}
+
+const debouncedGetDisplayDetails = useDebounceFn(getDisplayDetails, 500)
+
+onMounted(async () => {
+  await getDisplayDetails()
 
   addEventListener("resize", async () => {
-    screenDetails = await window.getScreenDetails()
-    currentScreen.value = screenDetails.currentScreen
+    debouncedGetDisplayDetails()
   })
+})
+
+onBeforeUnmount(() => {
+  removeEventListener("resize", debouncedGetDisplayDetails)
 })
 
 const moveCurrentScreenToNativeDisplay = async () => {
   const nativeDisplay = allScreens.value.find(
-    (screen: any) => screen?.isInternal
+    (screen: any) => screen?.isPrimary
   )
   document.documentElement.requestFullscreen({
     screen: nativeDisplay,

--- a/components/LiveProjectionOnly.vue
+++ b/components/LiveProjectionOnly.vue
@@ -105,7 +105,7 @@
       <LiveContent
         :content-visible="foregroundContentVisible"
         :slide="slide"
-        class="relative come-up-1"
+        class="relative"
         :class="fullScreen ? '' : 'min-h-[220px] rounded-md'"
         :padding="fullScreen ? '6' : '0'"
         :style="

--- a/components/LiveProjectionOnly.vue
+++ b/components/LiveProjectionOnly.vue
@@ -1,5 +1,13 @@
 <template>
-  <div class="live-output-ctn w-[100%] min-h-[220px] relative">
+  <div
+    class="live-output-ctn w-[100%] min-h-[220px] relative"
+    :class="{ 'no-animations': !currentState.settings.animations }"
+    :style="`transition-duration: ${
+      currentState.settings.animations
+        ? currentState.settings.transitionInterval
+        : 0
+    }s`"
+  >
     <div
       class="live-output w-[100%] min-h-[220px] rounded-md relative overflow-hidden border bg-no-repeat transition-all backdrop-blur-0 bg-black dark:border-none"
       v-if="contentVisible"

--- a/components/PreviewContent.vue
+++ b/components/PreviewContent.vue
@@ -798,7 +798,7 @@ const createNewMediaSlide = async (
       // Store Blob in DB for easy retrieval on reload
       await useIndexedDB().media.add({
         id: tempSlide.id,
-        content: file.blob,
+        content: { size: file.blob.size, type: file.blob.type },
         data: data as ArrayBuffer,
         createdAt: new Date().toISOString(),
         updatedAt: new Date().toISOString(),
@@ -817,7 +817,7 @@ const createNewMediaSlide = async (
 }
 
 const createMultipleNewMediaSlides = async (files: any[]) => {
-  console.log("files", files)
+  // console.log("files", files)
   useGlobalEmit(appWideActions.appLoading, true)
   const multipleSlidesPromise: Promise<any>[] = []
   files?.forEach((file) => {
@@ -1204,12 +1204,11 @@ const saveSlide = async (item: Slide) => {
     } else {
       delete tempItem.data.blob
       delete tempItem.blob
-      console.log("tempItem", tempItem)
       await db.library.add(
         {
           id: tempItem.id,
           type: "slide",
-          content: tempItem,
+          content: { ...tempItem },
           createdAt: new Date().toISOString(),
           updatedAt: new Date().toISOString(),
         },

--- a/components/ProfileSettings.vue
+++ b/components/ProfileSettings.vue
@@ -3,6 +3,7 @@
     <UFormGroup label="Full Name">
       <UInput
         class="border-0 shadow-none max-w-[250px]"
+        input-class=" bg-gray-100 dark:bg-gray-800 text-gray-900 dark:text-white"
         size="md"
         v-model="fullName"
       />
@@ -10,6 +11,7 @@
     <UFormGroup label="Email" class="mt-4">
       <UInput
         class="border-0 shadow-none max-w-[250px]"
+        input-class=" bg-gray-100 dark:bg-gray-800 text-gray-900 dark:text-white"
         size="md"
         v-model="email"
       />

--- a/components/SettingsModal.vue
+++ b/components/SettingsModal.vue
@@ -44,7 +44,7 @@
             {{ tab?.name }}
           </UButton>
         </div>
-        <div class="rhs w-[100%] rounded-lg p-6 pt-2 min-h-[600px]">
+        <div class="rhs w-[100%] rounded-lg p-6 pt-2 h-[600px]">
           <!-- SUB-SETTINGS HEADER -->
           <h3 class="font-semibold text-lg mb-4">
             {{ activeTab }}
@@ -65,6 +65,8 @@
             </div>
             <!-- PROFILE SETTINGS -->
             <ProfileSettings v-else-if="activeTab === 'Profile Settings'" />
+            <!-- DISPLAY SETTINGS -->
+            <DisplaySettings v-else-if="activeTab === 'Display Settings'" />
             <!-- SLIDE SETTINGS -->
             <SlideSettings
               v-else-if="activeTab === 'Slide Settings'"
@@ -104,6 +106,7 @@ const settingsModalOpen = ref(props.isOpen)
 const tabs = [
   { name: "Account Settings", active: false },
   { name: "Profile Settings", active: false },
+  { name: "Display Settings", active: false },
   { name: "Slide Settings", active: false },
   { name: "Bible Version Settings", active: false },
   { name: "Storage Settings", active: false },

--- a/components/SettingsModal.vue
+++ b/components/SettingsModal.vue
@@ -77,18 +77,7 @@
               v-else-if="activeTab === 'Bible Version Settings'"
             />
             <!-- STORAGE SETTINGS -->
-            <div
-              class="settings-ctn h-[100%]"
-              v-else-if="activeTab === 'Storage Settings'"
-            >
-              <EmptyState
-                icon="i-mdi-timer-sand-empty"
-                sub="Nothing to see for now"
-                action=""
-                action-text=""
-                class="pb-4"
-              />
-            </div>
+            <StorageSettings v-else-if="activeTab === 'Storage Settings'" />
           </Transition>
         </div>
       </div>

--- a/components/SlideMaxLinesSelect.vue
+++ b/components/SlideMaxLinesSelect.vue
@@ -59,7 +59,11 @@ const props = defineProps<{
 
 const appStore = useAppStore()
 const { currentState } = storeToRefs(appStore)
-const lines = ref<number>(props.selectedLine || 4)
+const lines = ref<number>(
+  props.selectedLine ||
+    currentState.value.settings.slideStyles.linesPerSlide ||
+    4
+)
 
 watch(
   () => props.selectedLine,

--- a/components/SlideSettings.vue
+++ b/components/SlideSettings.vue
@@ -6,7 +6,7 @@
           class="border-0 shadow-none w-[200px]"
           searchable
           searchable-placeholder="Search fonts"
-          select-class="w-[200px] bg-primary-100 dark:bg-primary-800 dark:text-white"
+          select-class="w-[200px] bg-gray-100 dark:bg-gray-800 dark:text-white"
           size="md"
           :options="appFonts"
           :model-value="appStore.currentState.settings.defaultFont"
@@ -46,7 +46,7 @@
             class="border-0 shadow-none max-w-[200px]"
             searchable
             searchable-placeholder="Search version"
-            select-class="w-[200px] bg-primary-100 dark:bg-primary-800 dark:text-white"
+            select-class="w-[200px]  bg-gray-100 dark:bg-gray-800 dark:text-white"
             size="md"
             :options="bibleVersionSelectOptions"
             :model-value="appStore.currentState.settings.defaultBibleVersion"
@@ -78,7 +78,7 @@
       <UFormGroup label="Set default slide alignment" class="mt-4">
         <USelectMenu
           class="border-0 shadow-none max-w-[200px] capitalize"
-          select-class="w-[200px] bg-primary-100 dark:bg-primary-800 dark:text-white capitalize"
+          select-class="w-[200px]  bg-gray-100 dark:bg-gray-800 dark:text-white capitalize"
           size="md"
           :options="['left', 'center', 'right']"
           :model-value="appStore.currentState.settings.slideStyles.alignment"

--- a/components/SlideSettings.vue
+++ b/components/SlideSettings.vue
@@ -1,101 +1,179 @@
 <template>
   <div class="settings-ctn h-[100%]">
-    <UForm>
-      <UFormGroup label="Set default font">
-        <USelectMenu
-          class="border-0 shadow-none w-[200px]"
-          searchable
-          searchable-placeholder="Search fonts"
-          select-class="w-[200px] bg-gray-100 dark:bg-gray-800 dark:text-white"
-          size="md"
-          :options="appFonts"
-          :model-value="appStore.currentState.settings.defaultFont"
-          variant="none"
-          color="primary"
-          clear-search-on-close
-          :ui="selectUI"
-          :ui-menu="selectMenuUI"
-          @change="appStore.setDefaultFont($event)"
-        >
-          <template #label>
-            <IconWrapper name="i-bx-font-family" size="4"> </IconWrapper>
-            <span
-              v-if="font?.length"
-              class="truncate"
-              :class="
-                useURLFriendlyString(appStore.currentState.settings.defaultFont)
-              "
-              >{{ appStore.currentState.settings.defaultFont }}</span
-            >
-            <span v-else>Select font</span>
-          </template>
-          <template #option="{ option: font }">
-            <span
-              v-if="font?.length"
-              class="truncate"
-              :class="useURLFriendlyString(font)"
-              >{{ font }}</span
-            >
-            <span v-else>Select font</span>
-          </template>
-        </USelectMenu>
-      </UFormGroup>
-      <div class="flex items-end gap-4">
-        <UFormGroup label="Set default Bible Version" class="mt-4">
+    <div class="settings-group">
+      <div class="flex items-center justify-between mb-4">
+        <h3 class="text-md font-semibold">Look and Feel</h3>
+      </div>
+
+      <!-- LOOK AND FEEL OF SLIDES -->
+      <UForm>
+        <UFormGroup label="Set default font">
           <USelectMenu
-            class="border-0 shadow-none max-w-[200px]"
+            class="border-0 shadow-none w-[200px]"
             searchable
-            searchable-placeholder="Search version"
-            select-class="w-[200px]  bg-gray-100 dark:bg-gray-800 dark:text-white"
+            searchable-placeholder="Search fonts"
+            select-class="w-[200px] bg-gray-100 dark:bg-gray-800 dark:text-white"
             size="md"
-            :options="bibleVersionSelectOptions"
-            :model-value="appStore.currentState.settings.defaultBibleVersion"
+            :options="appFonts"
+            :model-value="appStore.currentState.settings.defaultFont"
+            variant="none"
+            color="primary"
+            clear-search-on-close
+            :ui="selectUI"
+            :ui-menu="selectMenuUI"
+            @change="appStore.setDefaultFont($event)"
+          >
+            <template #label>
+              <IconWrapper name="i-bx-font-family" size="4"> </IconWrapper>
+              <span
+                v-if="font?.length"
+                class="truncate"
+                :class="
+                  useURLFriendlyString(
+                    appStore.currentState.settings.defaultFont
+                  )
+                "
+                >{{ appStore.currentState.settings.defaultFont }}</span
+              >
+              <span v-else>Select font</span>
+            </template>
+            <template #option="{ option: font }">
+              <span
+                v-if="font?.length"
+                class="truncate"
+                :class="useURLFriendlyString(font)"
+                >{{ font }}</span
+              >
+              <span v-else>Select font</span>
+            </template>
+          </USelectMenu>
+        </UFormGroup>
+        <UFormGroup label="Set default slide alignment" class="mt-4">
+          <USelectMenu
+            class="border-0 shadow-none max-w-[200px] capitalize"
+            select-class="w-[200px] bg-gray-100 dark:bg-gray-800 dark:text-white capitalize"
+            size="md"
+            :options="['left', 'center', 'right']"
+            :model-value="appStore.currentState.settings.slideStyles.alignment"
             variant="none"
             color="primary"
             clear-search-on-close
             :ui="selectUI"
             :ui-menu="selectMenuUI"
             @change="
-              $event === '+ More Versions'
-                ? useGlobalEmit(
-                    appWideActions.openSettings,
-                    'Bible Version Settings'
-                  )
-                : appStore.setDefaultBibleVersion($event)
+              appStore.setSlideStyles({
+                ...appStore.currentState.settings.slideStyles,
+                alignment: $event,
+              })
             "
+          />
+        </UFormGroup>
+      </UForm>
+    </div>
+
+    <!-- BIBLE SLIDES -->
+    <div class="settings-group border-gray-200 dark:border-gray-800 mt-8">
+      <div class="flex items-center justify-between mb-4">
+        <h3 class="text-md font-semibold">Bible Slides</h3>
+      </div>
+      <UForm>
+        <div class="flex items-end gap-4">
+          <UFormGroup label="Set default Bible Version">
+            <USelectMenu
+              class="border-0 shadow-none max-w-[200px]"
+              searchable
+              searchable-placeholder="Search version"
+              select-class="w-[200px]  bg-gray-100 dark:bg-gray-800 dark:text-white"
+              size="md"
+              :options="bibleVersionSelectOptions"
+              :model-value="appStore.currentState.settings.defaultBibleVersion"
+              variant="none"
+              color="primary"
+              clear-search-on-close
+              :ui="selectUI"
+              :ui-menu="selectMenuUI"
+              @change="
+                $event === '+ More Versions'
+                  ? useGlobalEmit(
+                      appWideActions.openSettings,
+                      'Bible Version Settings'
+                    )
+                  : appStore.setDefaultBibleVersion($event)
+              "
+            >
+            </USelectMenu>
+          </UFormGroup>
+          <UButton
+            size="md"
+            icon="i-bx-plus"
+            variant="outline"
+            @click="$emit('select-active-tab', 'Bible Version Settings')"
           >
+            Add more
+          </UButton>
+        </div>
+      </UForm>
+    </div>
+
+    <!-- SONG SLIDES -->
+    <div class="settings-group border-gray-200 dark:border-gray-800 mt-8">
+      <div class="flex items-center justify-between mb-4">
+        <h3 class="text-md font-semibold">Song Slides</h3>
+      </div>
+      <UForm>
+        <UFormGroup label="Set default lines per slide">
+          <USelectMenu
+            class="absolute border-0 shadow-none top-[6px]"
+            select-class="border-3 shadow-none outline-none text-center w-[200px] bg-gray-100 dark:bg-gray-800 dark:text-white"
+            size="md"
+            :options="['1', '2', '3', '4', '5', '6']"
+            v-model.number="lines"
+            variant="none"
+            color="primary"
+            clear-search-on-close
+            :ui="{
+              base: 'bg-primary-500',
+              input: 'bg-primary-500',
+              color: {
+                primary: {
+                  outline: 'shadow-sm bg-primary-500 ',
+                },
+              },
+            }"
+            :ui-menu="{
+              width: 'w-[200px]',
+              input: 'text-xs',
+              empty: 'text-xs',
+              option: {
+                size: 'text-xs',
+              },
+            }"
+            @change="appStore.setLinesPerSlide($event)"
+          >
+            <template #label>
+              <IconWrapper name="i-tabler-list-numbers" size="4"> </IconWrapper>
+              <span v-if="lines" class="truncate"
+                >{{ lines }} {{ lines > 1 ? "lines" : "line" }}</span
+              >
+              <span v-else class="truncate whitespace-nowrap"
+                >Lines per slide</span
+              >
+            </template>
+            <template #option="{ option: lines }">
+              <span
+                v-if="lines"
+                class="truncate"
+                :class="useURLFriendlyString(lines)"
+                >{{ lines }} {{ lines > 1 ? "lines" : "line" }}</span
+              >
+              <span v-else class="truncate whitespace-nowrap"
+                >Lines per slide</span
+              >
+            </template>
           </USelectMenu>
         </UFormGroup>
-        <UButton
-          size="md"
-          icon="i-bx-plus"
-          variant="outline"
-          @click="$emit('select-active-tab', 'Bible Version Settings')"
-        >
-          Add more
-        </UButton>
-      </div>
-      <UFormGroup label="Set default slide alignment" class="mt-4">
-        <USelectMenu
-          class="border-0 shadow-none max-w-[200px] capitalize"
-          select-class="w-[200px]  bg-gray-100 dark:bg-gray-800 dark:text-white capitalize"
-          size="md"
-          :options="['left', 'center', 'right']"
-          :model-value="appStore.currentState.settings.slideStyles.alignment"
-          variant="none"
-          color="primary"
-          clear-search-on-close
-          :ui="selectUI"
-          :ui-menu="selectMenuUI"
-          @change="
-            appStore.setSlideStyles({
-              ...appStore.currentState.settings.slideStyles,
-              alignment: $event,
-            })
-          "
-        />
-      </UFormGroup>
-    </UForm>
+      </UForm>
+    </div>
   </div>
 </template>
 
@@ -104,6 +182,9 @@ import { useAppStore } from "~/store/app"
 const appStore = useAppStore()
 
 const font = ref(appStore.currentState.settings.defaultFont)
+const lines = ref<number>(
+  appStore.currentState.settings.slideStyles.linesPerSlide || 4
+)
 const { currentState } = storeToRefs(appStore)
 const bibleVersionSelectOptions = computed(() =>
   [

--- a/components/SlideSettings.vue
+++ b/components/SlideSettings.vue
@@ -1,11 +1,10 @@
 <template>
-  <div class="settings-ctn h-[100%]">
+  <div class="settings-ctn h-[100%] overflow-y-auto mb-[2.5%] pb-[15%]">
+    <!-- LOOK AND FEEL OF SLIDES -->
     <div class="settings-group">
       <div class="flex items-center justify-between mb-4">
         <h3 class="text-md font-semibold">Look and Feel</h3>
       </div>
-
-      <!-- LOOK AND FEEL OF SLIDES -->
       <UForm>
         <UFormGroup label="Set default font">
           <USelectMenu
@@ -67,6 +66,42 @@
               })
             "
           />
+        </UFormGroup>
+      </UForm>
+    </div>
+
+    <!-- ANIMATION -->
+    <div class="settings-group border-gray-200 dark:border-gray-800 mt-8">
+      <div class="flex items-center justify-between mb-4">
+        <h3 class="text-md font-semibold">Animation & Transitions</h3>
+      </div>
+      <UForm>
+        <UFormGroup
+          label="Transition between slides and micro animations"
+          class=""
+        >
+          <UToggle
+            size="lg"
+            :model-value="appStore.currentState.settings.animations"
+            @change="appStore.setAnimations($event)"
+          />
+        </UFormGroup>
+        <UFormGroup
+          v-if="appStore.currentState.settings.animations"
+          label="Transition interval in seconds"
+          class="max-w-[200px] mt-4 come-up-1"
+        >
+          <div class="flex px-0 items-center gap-2 font-semibold">
+            <span class="text-sm">0s</span>
+            <URange
+              :model-value="appStore.currentState.settings.transitionInterval"
+              min="0"
+              max="5"
+              step="0.1"
+              @change="appStore.setTransitionInterval($event)"
+            />
+            <span class="text-sm"> 5s</span>
+          </div>
         </UFormGroup>
       </UForm>
     </div>

--- a/components/StorageSettings.vue
+++ b/components/StorageSettings.vue
@@ -5,7 +5,7 @@
         <Icon name="i-lucide-hard-drive" class="w-8 h-8" />
         <h3 class="text-lg font-semibold">
           {{ formatMegabytes(totalDataSize) }}
-          <span class="text-sm font-normal">stored locally</span>
+          <span class="text-sm font-normal">stored on this computer</span>
         </h3>
       </div>
       <Icon
@@ -82,7 +82,7 @@
               <div
                 class="colored-circle rounded-full w-3 h-3 bg-blue-500"
               ></div>
-              Slides Media
+              Media Slides (Images, Videos, Audio)
             </div>
           </td>
           <td>{{ formatMegabytes(mediaTableSize) }}</td>

--- a/components/StorageSettings.vue
+++ b/components/StorageSettings.vue
@@ -1,0 +1,174 @@
+<template>
+  <div class="settings-ctn h-[100%]">
+    <div class="header flex items-center justify-between gap-2">
+      <div class="col flex items-center gap-2">
+        <Icon name="i-lucide-hard-drive" class="w-8 h-8" />
+        <h3 class="text-lg font-semibold">
+          {{ formatMegabytes(totalDataSize) }}
+          <span class="text-sm font-normal">stored locally</span>
+        </h3>
+      </div>
+      <Icon
+        v-if="loading"
+        name="i-lucide-loader-2"
+        class="w-6 h-6 animate-spin"
+      />
+    </div>
+    <div class="storage-chart flex rounded-full overflow-hidden my-2 w-full">
+      <div
+        class="storage-chart-bar-inner h-[10px] bg-primary-500 transition-all"
+        :style="{
+          width: `${(cachedTableSize / totalDataSize) * 100}%`,
+        }"
+      ></div>
+      <div
+        class="storage-chart-bar-inner h-[10px] bg-teal-500 transition-all"
+        :style="{
+          width: `${(libraryTableSize / totalDataSize) * 100}%`,
+        }"
+      ></div>
+      <div
+        class="storage-chart-bar-inner h-[10px] bg-cyan-500 transition-all"
+        :style="{
+          width: `${(bibleAndHymnsTableSize / totalDataSize) * 100}%`,
+        }"
+      ></div>
+      <div
+        class="storage-chart-bar-inner h-[10px] bg-blue-500 transition-all"
+        :style="{
+          width: `${(mediaTableSize / totalDataSize) * 100}%`,
+        }"
+      ></div>
+    </div>
+
+    <table class="table-auto w-full">
+      <tbody>
+        <tr class="border-b border-gray-200 dark:border-gray-800 h-[50px]">
+          <td>
+            <div class="flex items-center gap-2">
+              <div
+                class="colored-circle rounded-full w-3 h-3 bg-primary-500"
+              ></div>
+              Background Videos and Images
+            </div>
+          </td>
+          <td>{{ formatMegabytes(cachedTableSize) }}</td>
+        </tr>
+        <tr class="border-b border-gray-200 dark:border-gray-800 h-[50px]">
+          <td>
+            <div class="flex items-center gap-2">
+              <div
+                class="colored-circle rounded-full w-3 h-3 bg-teal-500"
+              ></div>
+              Library Items
+            </div>
+          </td>
+          <td>{{ formatMegabytes(libraryTableSize) }}</td>
+        </tr>
+        <tr class="border-b border-gray-200 dark:border-gray-800 h-[50px]">
+          <td>
+            <div class="flex items-center gap-2">
+              <div
+                class="colored-circle rounded-full w-3 h-3 bg-cyan-500"
+              ></div>
+              Bible versions and hymns
+            </div>
+          </td>
+          <td>{{ formatMegabytes(bibleAndHymnsTableSize) }}</td>
+        </tr>
+        <tr class="border-gray-200 dark:border-gray-800 h-[50px]">
+          <td>
+            <div class="flex items-center gap-2">
+              <div
+                class="colored-circle rounded-full w-3 h-3 bg-blue-500"
+              ></div>
+              Slides Media
+            </div>
+          </td>
+          <td>{{ formatMegabytes(mediaTableSize) }}</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { Media } from "~/types"
+
+const db = useIndexedDB()
+const loading = ref<boolean>(true)
+const cachedTableSize = ref<number>(0)
+const libraryTableSize = ref<number>(0)
+const bibleAndHymnsTableSize = ref<number>(0)
+const mediaTableSize = ref<number>(0)
+
+const totalDataSize = computed(() => {
+  return (
+    cachedTableSize.value +
+    libraryTableSize.value +
+    bibleAndHymnsTableSize.value +
+    mediaTableSize.value
+  )
+})
+
+const formatMegabytes = (sizeInMegabytes: number) => {
+  if (sizeInMegabytes >= 1024) {
+    return `${sizeInMegabytes.toFixed(2)} GB`
+  } else {
+    return `${sizeInMegabytes.toFixed(2)} MB`
+  }
+}
+
+const getStoreSize = async (store: any) => {
+  let storeSize = 0
+  await store.each((item: any) => {
+    const itemSize = new Blob([JSON.stringify(item)]).size
+    storeSize += itemSize
+  })
+  return storeSize
+}
+
+const calculateMediaTableSize = async () => {
+  let totalSize = 0
+  // console.log("mediaTableSize", await db.media.count())
+  await db.media.each((item: Media) => {
+    totalSize += item?.data?.byteLength || 0
+  })
+  mediaTableSize.value = totalSize / 1024 / 1024
+}
+
+const calculateBackgroundVideosAndImagesTableSize = async () => {
+  let totalSize = 0
+  db.cached.count
+  await db.cached.each((item: any) => {
+    totalSize += item?.data?.size || 0
+  })
+  cachedTableSize.value = totalSize / 1024 / 1024
+}
+
+const calculateLibraryTableSize = async () => {
+  libraryTableSize.value = (await getStoreSize(db.library)) / 1024 / 1024
+}
+
+const calculateBibleAndHymnsTableSize = async () => {
+  bibleAndHymnsTableSize.value =
+    (await getStoreSize(db.bibleAndHymns)) / 1024 / 1024
+}
+
+// calculateMediaTableSize()
+// calculateBackgroundVideosAndImagesTableSize()
+// calculateLibraryTableSize()
+// calculateBibleAndHymnsTableSize()
+// loading.value = false
+
+onMounted(async () => {
+  loading.value = true
+  await calculateMediaTableSize()
+  await calculateBackgroundVideosAndImagesTableSize()
+  await calculateLibraryTableSize()
+  await calculateBibleAndHymnsTableSize()
+  loading.value = false
+})
+</script>
+
+<style scoped></style>

--- a/components/StorageSettings.vue
+++ b/components/StorageSettings.vue
@@ -100,6 +100,7 @@
         v-if="deletePrompt"
         v-model="deletePromptText"
         placeholder="Type 'intentionally deleting' to confirm"
+        input-class=" bg-white dark:bg-gray-800 text-gray-900 dark:text-white"
         class="mb-4"
         size="xs"
       >

--- a/components/StorageSettings.vue
+++ b/components/StorageSettings.vue
@@ -89,6 +89,34 @@
         </tr>
       </tbody>
     </table>
+
+    <div class="danger-zone mt-4 bg-red-100 dark:bg-red-900 rounded-md p-4">
+      <h3 class="font-medium">Danger Zone</h3>
+      <p class="text-xs mb-4 mt-2">
+        This is a danger zone. If you are not sure what you are doing, do not
+        delete anything here. If you are sure, click the button below.
+      </p>
+      <UInput
+        v-if="deletePrompt"
+        v-model="deletePromptText"
+        placeholder="Type 'intentionally deleting' to confirm"
+        class="mb-4"
+        size="xs"
+      >
+      </UInput>
+      <UButton
+        color="danger"
+        block
+        icon="i-bx-trash"
+        variant="outline"
+        :disabled="
+          deletePrompt ? deletePromptText !== 'intentionally deleting' : false
+        "
+        @click="deletePrompt ? deleteAllData() : (deletePrompt = true)"
+      >
+        Clear all data on this device
+      </UButton>
+    </div>
   </div>
 </template>
 
@@ -101,6 +129,8 @@ const cachedTableSize = ref<number>(0)
 const libraryTableSize = ref<number>(0)
 const bibleAndHymnsTableSize = ref<number>(0)
 const mediaTableSize = ref<number>(0)
+const deletePrompt = ref<boolean>(false)
+const deletePromptText = ref<string>("")
 
 const totalDataSize = computed(() => {
   return (
@@ -153,6 +183,16 @@ const calculateLibraryTableSize = async () => {
 const calculateBibleAndHymnsTableSize = async () => {
   bibleAndHymnsTableSize.value =
     (await getStoreSize(db.bibleAndHymns)) / 1024 / 1024
+}
+
+const deleteAllData = async () => {
+  loading.value = true
+  console.log("deleting all data")
+
+  await db.delete()
+  deletePrompt.value = false
+  deletePromptText.value = ""
+  loading.value = false
 }
 
 // calculateMediaTableSize()

--- a/layouts/app.vue
+++ b/layouts/app.vue
@@ -783,6 +783,15 @@ async function openWindows() {
   const screenDetails = await window.getScreenDetails()
   const noOfScreens = screenDetails.screens.length
 
+  if (!appStore.currentState.mainDisplayLabel) {
+    useToast().add({
+      title: "Set up your main display first",
+      icon: "i-bx-info-circle",
+    })
+    useGlobalEmit(appWideActions.openSettings, "Display Settings")
+    return
+  }
+
   if (noOfScreens === 1) {
     useToast().add({
       title:
@@ -803,11 +812,14 @@ async function openWindows() {
     // Two screens or more
     const screen1 = screenDetails.screens[0]
     const screen2 = screenDetails.screens[1]
+    const mainDisplayScreen = screenDetails.screens?.find(
+      (screen: any) => screen.label === appStore.currentState.mainDisplayLabel
+    )
     openWindow(
-      screen1.availLeft,
-      screen1.availTop,
-      screen2.availWidth,
-      screen2.availHeight,
+      mainDisplayScreen.availLeft,
+      mainDisplayScreen.availTop,
+      mainDisplayScreen.availWidth,
+      mainDisplayScreen.availHeight,
       `http://${window.location.host}/live`
     )
   }

--- a/layouts/app.vue
+++ b/layouts/app.vue
@@ -275,7 +275,7 @@ const getChurch = async () => {
 }
 getChurch()
 
-// Get hymn count
+// Get hymn count and download app info
 let hymnCount: any
 const hymns = await db.bibleAndHymns.get("hymns")
 if (isAppOnline.value) {
@@ -284,6 +284,12 @@ if (isAppOnline.value) {
       Authorization: `Bearer ${token.value}`,
     },
   })
+  // Download app info
+  const { data } = await useAPIFetch("/app-config/info")
+  if (data.value) {
+    appInfo.value = data.value as any
+    appStore.setBibleVersions(data.value?.bibleVersions)
+  }
   hymnCount = await hymnCount.json()
 } else {
   // Handle offline hymn count
@@ -484,11 +490,6 @@ const downloadEssentialResources = async () => {
   // Download background videos
   downloadStep.value = 2
   await retrieveSchedules()
-
-  // Download app info
-  const { data } = await useAPIFetch("/app-config/info")
-  appInfo.value = data.value as any
-  appStore.setBibleVersions(data.value?.bibleVersions)
 
   // Download KJV Bible
   let tempBible = await db.bibleAndHymns.get("KJV")

--- a/layouts/app.vue
+++ b/layouts/app.vue
@@ -785,7 +785,7 @@ async function openWindows() {
 
   if (!appStore.currentState.mainDisplayLabel) {
     useToast().add({
-      title: "Set up your main display first",
+      title: "Set up your live display first",
       icon: "i-bx-info-circle",
     })
     useGlobalEmit(appWideActions.openSettings, "Display Settings")
@@ -810,18 +810,25 @@ async function openWindows() {
     )
   } else {
     // Two screens or more
-    const screen1 = screenDetails.screens[0]
-    const screen2 = screenDetails.screens[1]
+    // const screen1 = screenDetails.screens[0]
+    // const screen2 = screenDetails.screens[1]
     const mainDisplayScreen = screenDetails.screens?.find(
       (screen: any) => screen.label === appStore.currentState.mainDisplayLabel
     )
-    openWindow(
-      mainDisplayScreen.availLeft,
-      mainDisplayScreen.availTop,
-      mainDisplayScreen.availWidth,
-      mainDisplayScreen.availHeight,
-      `http://${window.location.host}/live`
-    )
+    if (mainDisplayScreen) {
+      openWindow(
+        mainDisplayScreen.availLeft,
+        mainDisplayScreen.availTop,
+        mainDisplayScreen.availWidth,
+        mainDisplayScreen.availHeight,
+        `http://${window.location.host}/live`
+      )
+    } else {
+      useToast().add({
+        title: "Unable to find live display, update your display settings",
+        icon: "i-bx-info-circle",
+      })
+    }
   }
 
   const closeMonitor = setInterval(checkWindowClose, 250)

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -95,7 +95,15 @@ export default defineNuxtConfig({
 
   css: ["~/assets/css/main.css"],
 
-  modules: ["@nuxt/ui", "@vite-pwa/nuxt", "nuxt-tiptap-editor", "@pinia/nuxt", "pinia-plugin-persistedstate/nuxt", "nuxt-gtag"],
+  modules: [
+    "@nuxt/ui",
+    "@vite-pwa/nuxt",
+    "nuxt-tiptap-editor",
+    "@pinia/nuxt",
+    "pinia-plugin-persistedstate/nuxt",
+    "nuxt-gtag",
+    "@nuxthub/core"
+  ],
 
   ui: {
     global: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
         "@aws-sdk/client-s3": "^3.540.0",
         "@hotjar/browser": "^1.0.9",
         "@nuxt/ui": "npm:@nuxt/ui-edge@latest",
+        "@nuxthub/core": "^0.8.4",
         "@pinia/nuxt": "^0.5.1",
         "@tiptap/extension-font-family": "^2.4.0",
         "@tiptap/extension-highlight": "^2.3.0",
@@ -54,7 +55,8 @@
         "@tauri-apps/cli": "^1.5.14",
         "@types/socket.io-client": "^3.0.0",
         "typescript": "^5.4.5",
-        "vue-tsc": "^2.0.16"
+        "vue-tsc": "^2.0.16",
+        "wrangler": "^3.84.1"
       },
       "optionalDependencies": {
         "@esbuild/linux-x64": "0.24.0",
@@ -2725,9 +2727,10 @@
       "integrity": "sha512-BxOqI5LgsIQP1odU5KMwV9yoijleOPzHL18/YvNqF9KFSGF2K/DLlYAbDQsWqd/1nbaFuSkYD/191dpMtNh4vw=="
     },
     "node_modules/@cloudflare/kv-asset-handler": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.3.2.tgz",
-      "integrity": "sha512-EeEjMobfuJrwoctj7FA1y1KEbM0+Q1xSjobIEyie9k4haVEBB7vkDvsasw1pM3rO39mL2akxIAzLMUAtrMHZhA==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.3.4.tgz",
+      "integrity": "sha512-YLPHc8yASwjNkmcDMQMY35yiWjoKAKnhUbPRszBRS0YgH+IXtsMp61j+yTcnCE3oO2DgP0U3iejLC8FTtKDC8Q==",
+      "license": "MIT OR Apache-2.0",
       "dependencies": {
         "mime": "^3.0.0"
       },
@@ -2744,6 +2747,148 @@
       },
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20241022.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20241022.0.tgz",
+      "integrity": "sha512-1NNYun37myMTgCUiPQEJ0cMal4mKZVTpkD0b2tx9hV70xji+frVJcSK8YVLeUm1P+Rw1d/ct8DMgQuCpsz3Fsw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20241022.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20241022.0.tgz",
+      "integrity": "sha512-FOO/0P0U82EsTLTdweNVgw+4VOk5nghExLPLSppdOziq6IR5HVgP44Kmq5LdsUeHUhwUmfOh9hzaTpkNzUqKvw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20241022.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20241022.0.tgz",
+      "integrity": "sha512-RsNc19BQJG9yd+ngnjuDeG9ywZG+7t1L4JeglgceyY5ViMNMKVO7Zpbsu69kXslU9h6xyQG+lrmclg3cBpnhYA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20241022.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20241022.0.tgz",
+      "integrity": "sha512-x5mUXpKxfsosxcFmcq5DaqLs37PejHYVRsNz1cWI59ma7aC4y4Qn6Tf3i0r9MwQTF/MccP4SjVslMU6m4W7IaA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20241022.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20241022.0.tgz",
+      "integrity": "sha512-eBCClx4szCOgKqOlxxbdNszMqQf3MRG1B9BRIqEM/diDfdR9IrZ8l3FaEm+l9gXgPmS6m1NBn40aWuGBl8UTSw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workers-shared": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-shared/-/workers-shared-0.7.0.tgz",
+      "integrity": "sha512-LLQRTqx7lKC7o2eCYMpyc5FXV8d0pUX6r3A+agzhqS9aoR5A6zCPefwQGcvbKx83ozX22ATZcemwxQXn12UofQ==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "mime": "^3.0.0",
+        "zod": "^3.22.3"
+      },
+      "engines": {
+        "node": ">=16.7.0"
+      }
+    },
+    "node_modules/@cloudflare/workers-shared/node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "4.20241022.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20241022.0.tgz",
+      "integrity": "sha512-1zOAw5QIDKItzGatzCrEpfLOB1AuMTwVqKmbw9B9eBfCUGRFNfJYMrJxIwcse9EmKahsQt2GruqU00pY/GyXgg==",
+      "license": "MIT OR Apache-2.0"
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "node_modules/@csstools/selector-resolve-nested": {
@@ -2797,6 +2942,43 @@
       },
       "peerDependencies": {
         "tailwindcss": "*"
+      }
+    },
+    "node_modules/@esbuild-plugins/node-globals-polyfill": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@esbuild-plugins/node-globals-polyfill/-/node-globals-polyfill-0.2.3.tgz",
+      "integrity": "sha512-r3MIryXDeXDOZh7ih1l/yE9ZLORCd5e8vWg02azWRGj5SPTuoh69A2AIyn0Z31V/kHBfZ4HgWJ+OK3GTTwLmnw==",
+      "dev": true,
+      "license": "ISC",
+      "peerDependencies": {
+        "esbuild": "*"
+      }
+    },
+    "node_modules/@esbuild-plugins/node-modules-polyfill": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@esbuild-plugins/node-modules-polyfill/-/node-modules-polyfill-0.2.2.tgz",
+      "integrity": "sha512-LXV7QsWJxRuMYvKbiznh+U1ilIop3g2TeKRzUxOG5X3YITc8JyyTa90BmLwqqv0YnX4v32CSlG+vsziZp9dMvA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0",
+        "rollup-plugin-node-polyfills": "^0.2.1"
+      },
+      "peerDependencies": {
+        "esbuild": "*"
+      }
+    },
+    "node_modules/@esbuild-plugins/node-modules-polyfill/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -4751,6 +4933,101 @@
       },
       "peerDependencies": {
         "vue": "^3.3.4"
+      }
+    },
+    "node_modules/@nuxthub/core": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/@nuxthub/core/-/core-0.8.4.tgz",
+      "integrity": "sha512-sXzHVHzIYdIOvhPq/4jkOgmLmQEg8uWozyignbTBrvdtDgxr1NBwQER7+1+SfkpDxbmkpJ5gL1DK9RtZKXBRKQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cloudflare/workers-types": "^4.20241022.0",
+        "@nuxt/devtools-kit": "^1.6.0",
+        "@nuxt/kit": "^3.13.2",
+        "@uploadthing/mime-types": "^0.3.1",
+        "citty": "^0.1.6",
+        "confbox": "^0.1.8",
+        "defu": "^6.1.4",
+        "destr": "^2.0.3",
+        "h3": "^1.13.0",
+        "mime": "^4.0.4",
+        "nitro-cloudflare-dev": "^0.2.1",
+        "ofetch": "^1.4.1",
+        "pathe": "^1.1.2",
+        "pkg-types": "^1.2.1",
+        "std-env": "^3.7.0",
+        "ufo": "^1.5.4",
+        "uncrypto": "^0.1.3",
+        "unstorage": "^1.12.0",
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@nuxthub/core/node_modules/@nuxt/devtools-kit": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@nuxt/devtools-kit/-/devtools-kit-1.6.0.tgz",
+      "integrity": "sha512-kJ8mVKwTSN3tdEVNy7mxKCiQk9wsG5t3oOrRMWk6IEbTSov+5sOULqQSM/+OWxWsEDmDfA7QlS5sM3Ti9uMRqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@nuxt/kit": "^3.13.2",
+        "@nuxt/schema": "^3.13.2",
+        "execa": "^7.2.0"
+      },
+      "peerDependencies": {
+        "vite": "*"
+      }
+    },
+    "node_modules/@nuxthub/core/node_modules/@nuxt/kit": {
+      "version": "3.13.2",
+      "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.13.2.tgz",
+      "integrity": "sha512-KvRw21zU//wdz25IeE1E5m/aFSzhJloBRAQtv+evcFeZvuroIxpIQuUqhbzuwznaUwpiWbmwlcsp5uOWmi4vwA==",
+      "license": "MIT",
+      "dependencies": {
+        "@nuxt/schema": "3.13.2",
+        "c12": "^1.11.2",
+        "consola": "^3.2.3",
+        "defu": "^6.1.4",
+        "destr": "^2.0.3",
+        "globby": "^14.0.2",
+        "hash-sum": "^2.0.0",
+        "ignore": "^5.3.2",
+        "jiti": "^1.21.6",
+        "klona": "^2.0.6",
+        "knitwork": "^1.1.0",
+        "mlly": "^1.7.1",
+        "pathe": "^1.1.2",
+        "pkg-types": "^1.2.0",
+        "scule": "^1.3.0",
+        "semver": "^7.6.3",
+        "ufo": "^1.5.4",
+        "unctx": "^2.3.1",
+        "unimport": "^3.12.0",
+        "untyped": "^1.4.2"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
+      }
+    },
+    "node_modules/@nuxthub/core/node_modules/@nuxt/schema": {
+      "version": "3.13.2",
+      "resolved": "https://registry.npmjs.org/@nuxt/schema/-/schema-3.13.2.tgz",
+      "integrity": "sha512-CCZgpm+MkqtOMDEgF9SWgGPBXlQ01hV/6+2reDEpJuqFPGzV8HYKPBcIFvn7/z5ahtgutHLzjP71Na+hYcqSpw==",
+      "license": "MIT",
+      "dependencies": {
+        "compatx": "^0.1.8",
+        "consola": "^3.2.3",
+        "defu": "^6.1.4",
+        "hookable": "^5.5.3",
+        "pathe": "^1.1.2",
+        "pkg-types": "^1.2.0",
+        "scule": "^1.3.0",
+        "std-env": "^3.7.0",
+        "ufo": "^1.5.4",
+        "uncrypto": "^0.1.3",
+        "unimport": "^3.12.0",
+        "untyped": "^1.4.2"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
       }
     },
     "node_modules/@nuxtjs/color-mode": {
@@ -7011,6 +7288,16 @@
         "undici-types": "~5.26.4"
       }
     },
+    "node_modules/@types/node-forge": {
+      "version": "1.3.11",
+      "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.11.tgz",
+      "integrity": "sha512-FQx220y22OKNTqaByeBGqHWYz4cl94tpcxeFdvBo3wjG6XPBuZ0BNgNZRV5J5TFmmcsJ4IzsLkmGRiQbnYsBEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/resolve": {
       "version": "1.20.2",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
@@ -7468,6 +7755,12 @@
       "peerDependencies": {
         "vite": "^2.9.0 || ^3.0.0-0 || ^4.0.0 || ^5.0.0-0"
       }
+    },
+    "node_modules/@uploadthing/mime-types": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@uploadthing/mime-types/-/mime-types-0.3.1.tgz",
+      "integrity": "sha512-CaEadjn33CzPSLRaU8uL8IRv8MpW9xU5Rg/R45T5In8608dzovDDk0uQ9jzmmLYU5hHt+4v2qugcG/jirm/KEA==",
+      "license": "MIT"
     },
     "node_modules/@vercel/nft": {
       "version": "0.26.5",
@@ -8310,6 +8603,19 @@
         "acorn": "^8"
       }
     },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
@@ -8572,6 +8878,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/as-table": {
+      "version": "1.0.55",
+      "resolved": "https://registry.npmjs.org/as-table/-/as-table-1.0.55.tgz",
+      "integrity": "sha512-xvsWESUJn0JN421Xb9MQw6AsMHRCUknCe0Wjlxvjud80mU4E6hQf1A6NzQKcYNmYw62MfzEtXc+badstZP3JpQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "printable-characters": "^1.0.42"
       }
     },
     "node_modules/ast-kit": {
@@ -8865,6 +9181,13 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/boolbase": {
       "version": "1.0.0",
@@ -9206,6 +9529,17 @@
         }
       ]
     },
+    "node_modules/capnp-ts": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/capnp-ts/-/capnp-ts-0.7.0.tgz",
+      "integrity": "sha512-XKxXAC3HVPv7r674zP0VC3RTXz+/JKhfyw94ljvF80yynK6VkTnqE3jMuN8b3dUVmmc43TjyxjW4KTsmB3c86g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.1",
+        "tslib": "^2.2.0"
+      }
+    },
     "node_modules/chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -9527,9 +9861,10 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
     "node_modules/confbox": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.7.tgz",
-      "integrity": "sha512-uJcB/FKZtBMCJpK8MQji6bJHgu1tixKPxRLeGkNzBoOZzpnZUJm0jm2/sBDWcuBx1dYgxV4JU+g5hmNxCyAmdA=="
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "license": "MIT"
     },
     "node_modules/consola": {
       "version": "3.2.3",
@@ -9568,10 +9903,21 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="
     },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/cookie-es": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-1.1.0.tgz",
-      "integrity": "sha512-L2rLOcK0wzWSfSDA33YR+PUHDG10a8px7rUHKWbGLP4YfbsMed2KFUw5fczvDPbT98DDe3LEzviswl810apTEw=="
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-1.2.2.tgz",
+      "integrity": "sha512-+W7VmiVINB+ywl1HGXJXmrqkOhpKrIiVZV6tQuV54ZyQC7MMuBt81Vc336GMLoHBq5hV/F9eXgt5Mnx0Rha5Fg==",
+      "license": "MIT"
     },
     "node_modules/cookies": {
       "version": "0.9.1",
@@ -9867,6 +10213,13 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-2.0.2.tgz",
+      "integrity": "sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/data-view-buffer": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.1.tgz",
@@ -9913,6 +10266,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/db0": {
@@ -10675,6 +11039,19 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
+    "node_modules/exit-hook": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-2.2.1.tgz",
+      "integrity": "sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/expand-template": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
@@ -11088,6 +11465,27 @@
       "resolved": "https://registry.npmjs.org/get-port-please/-/get-port-please-3.1.2.tgz",
       "integrity": "sha512-Gxc29eLs1fbn6LQ4jSU4vXjlwyZhF5HsGuMAa7gqBP4Rw4yxxltyDUuF5MBclFzDTXO+ACchGQoeela4DSfzdQ=="
     },
+    "node_modules/get-source": {
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/get-source/-/get-source-2.0.12.tgz",
+      "integrity": "sha512-X5+4+iD+HoSeEED+uwrQ07BOQr0kEDFMVqqpBuI+RaZBpBpHCuXxo70bjar6f0b0u/DQJsJ7ssurpP0V60Az+w==",
+      "dev": true,
+      "license": "Unlicense",
+      "dependencies": {
+        "data-uri-to-buffer": "^2.0.0",
+        "source-map": "^0.6.1"
+      }
+    },
+    "node_modules/get-source/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/get-stream": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
@@ -11193,6 +11591,13 @@
         "node": ">= 6"
       }
     },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/global-directory": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/global-directory/-/global-directory-4.0.1.tgz",
@@ -11281,20 +11686,21 @@
       }
     },
     "node_modules/h3": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/h3/-/h3-1.11.1.tgz",
-      "integrity": "sha512-AbaH6IDnZN6nmbnJOH72y3c5Wwh9P97soSVdGSBbcDACRdkC0FEWf25pzx4f/NuOCK6quHmW18yF2Wx+G4Zi1A==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/h3/-/h3-1.13.0.tgz",
+      "integrity": "sha512-vFEAu/yf8UMUcB4s43OaDaigcqpQd14yanmOsn+NcRX3/guSKncyE2rOYhq8RIchgJrPSs/QiIddnTTR1ddiAg==",
+      "license": "MIT",
       "dependencies": {
-        "cookie-es": "^1.0.0",
-        "crossws": "^0.2.2",
+        "cookie-es": "^1.2.2",
+        "crossws": ">=0.2.0 <0.4.0",
         "defu": "^6.1.4",
         "destr": "^2.0.3",
-        "iron-webcrypto": "^1.0.0",
-        "ohash": "^1.1.3",
-        "radix3": "^1.1.0",
-        "ufo": "^1.4.0",
+        "iron-webcrypto": "^1.2.1",
+        "ohash": "^1.1.4",
+        "radix3": "^1.1.2",
+        "ufo": "^1.5.4",
         "uncrypto": "^0.1.3",
-        "unenv": "^1.9.0"
+        "unenv": "^1.10.0"
       }
     },
     "node_modules/has-bigints": {
@@ -12167,6 +12573,13 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
+    "node_modules/itty-time": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/itty-time/-/itty-time-1.0.6.tgz",
+      "integrity": "sha512-+P8IZaLLBtFv8hCkIjcymZOp4UJ+xW6bSlQsXGqrkmJh7vSiMFSlNne0mCYagEE0N7HDNR5jJBRxwN0oYv61Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/jackspeak": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.0.tgz",
@@ -12660,32 +13073,42 @@
       "integrity": "sha512-auMesunaJ8yfkHvK4gfg1K0SaKX/6Wn9g2Aac/NwX+l5VdmFZzo/hdPGxEOETj+ryRa4/fiOPjeeKURSAJx1sg=="
     },
     "node_modules/listhen": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/listhen/-/listhen-1.7.2.tgz",
-      "integrity": "sha512-7/HamOm5YD9Wb7CFgAZkKgVPA96WwhcTQoqtm2VTZGVbVVn3IWKRBTgrU7cchA3Q8k9iCsG8Osoi9GX4JsGM9g==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/listhen/-/listhen-1.9.0.tgz",
+      "integrity": "sha512-I8oW2+QL5KJo8zXNWX046M134WchxsXC7SawLPvRQpogCbkyQIaFxPE89A2HiwR7vAK2Dm2ERBAmyjTYGYEpBg==",
+      "license": "MIT",
       "dependencies": {
         "@parcel/watcher": "^2.4.1",
         "@parcel/watcher-wasm": "^2.4.1",
         "citty": "^0.1.6",
         "clipboardy": "^4.0.0",
         "consola": "^3.2.3",
-        "crossws": "^0.2.0",
+        "crossws": ">=0.2.0 <0.4.0",
         "defu": "^6.1.4",
         "get-port-please": "^3.1.2",
-        "h3": "^1.10.2",
+        "h3": "^1.12.0",
         "http-shutdown": "^1.2.2",
-        "jiti": "^1.21.0",
-        "mlly": "^1.6.1",
+        "jiti": "^2.1.2",
+        "mlly": "^1.7.1",
         "node-forge": "^1.3.1",
         "pathe": "^1.1.2",
         "std-env": "^3.7.0",
-        "ufo": "^1.4.0",
+        "ufo": "^1.5.4",
         "untun": "^0.1.3",
         "uqr": "^0.1.2"
       },
       "bin": {
         "listen": "bin/listhen.mjs",
         "listhen": "bin/listhen.mjs"
+      }
+    },
+    "node_modules/listhen/node_modules/jiti": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.0.tgz",
+      "integrity": "sha512-H5UpaUI+aHOqZXlYOaFP/8AzKsg+guWu+Pr3Y8i7+Y3zr1aXAvCvTAQ1RxSc6oVD8R8c7brgNtTVP91E7upH/g==",
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
       }
     },
     "node_modules/local-pkg": {
@@ -12948,12 +13371,13 @@
       }
     },
     "node_modules/mime": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-4.0.3.tgz",
-      "integrity": "sha512-KgUb15Oorc0NEKPbvfa0wRU+PItIEZmiv+pyAO2i0oTIVTJhlzMclU7w4RXWQrSOVH5ax/p/CkIO7KI4OyFJTQ==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-4.0.4.tgz",
+      "integrity": "sha512-v8yqInVjhXyqP6+Kw4fV3ZzeMRqEW6FotRsKXjRS5VMTNIuXsdRoAvklpoRgSqXm6o9VNH4/C0mgedko9DdLsQ==",
       "funding": [
         "https://github.com/sponsors/broofa"
       ],
+      "license": "MIT",
       "bin": {
         "mime": "bin/cli.js"
       },
@@ -13008,6 +13432,33 @@
       "integrity": "sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==",
       "bin": {
         "mini-svg-data-uri": "cli.js"
+      }
+    },
+    "node_modules/miniflare": {
+      "version": "3.20241022.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20241022.0.tgz",
+      "integrity": "sha512-x9Fbq1Hmz1f0osIT9Qmj78iX4UpCP2EqlZnA/tzj/3+I49vc3Kq0fNqSSKplcdf6HlCHdL3fOBicmreQF4BUUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "acorn": "^8.8.0",
+        "acorn-walk": "^8.2.0",
+        "capnp-ts": "^0.7.0",
+        "exit-hook": "^2.2.1",
+        "glob-to-regexp": "^0.4.1",
+        "stoppable": "^1.1.0",
+        "undici": "^5.28.4",
+        "workerd": "1.20241022.0",
+        "ws": "^8.17.1",
+        "youch": "^3.2.2",
+        "zod": "^3.22.3"
+      },
+      "bin": {
+        "miniflare": "bootstrap.js"
+      },
+      "engines": {
+        "node": ">=16.13"
       }
     },
     "node_modules/minimatch": {
@@ -13220,14 +13671,27 @@
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
     },
     "node_modules/mlly": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.7.1.tgz",
-      "integrity": "sha512-rrVRZRELyQzrIUAVMHxP97kv+G786pHmOKzuFII8zDYahFBS7qnHh2AlYSl1GAHhaMPCz6/oHjVMcfFYgFYHgA==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.7.2.tgz",
+      "integrity": "sha512-tN3dvVHYVz4DhSXinXIk7u9syPYaJvio118uomkovAtWBT+RdbP6Lfh/5Lvo519YMmwBafwlh20IPTXIStscpA==",
+      "license": "MIT",
       "dependencies": {
-        "acorn": "^8.11.3",
+        "acorn": "^8.12.1",
         "pathe": "^1.1.2",
-        "pkg-types": "^1.1.1",
-        "ufo": "^1.5.3"
+        "pkg-types": "^1.2.0",
+        "ufo": "^1.5.4"
+      }
+    },
+    "node_modules/mlly/node_modules/acorn": {
+      "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/mri": {
@@ -13256,6 +13720,16 @@
       "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.4.1.tgz",
       "integrity": "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==",
       "devOptional": true
+    },
+    "node_modules/mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      }
     },
     "node_modules/mz": {
       "version": "2.7.0",
@@ -13295,6 +13769,17 @@
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/nitro-cloudflare-dev": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/nitro-cloudflare-dev/-/nitro-cloudflare-dev-0.2.1.tgz",
+      "integrity": "sha512-zHAN21dp+As0ldkAr5tWTop/I721j7MssZG6qb7a7EMorFwdRIhyTUwltr2L6v4qT4209S4eb2S9rszP1fxS7A==",
+      "license": "MIT",
+      "dependencies": {
+        "consola": "^3.2.3",
+        "mlly": "^1.7.2",
+        "pkg-types": "^1.2.1"
       }
     },
     "node_modules/nitropack": {
@@ -14067,19 +14552,21 @@
       }
     },
     "node_modules/ofetch": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.3.4.tgz",
-      "integrity": "sha512-KLIET85ik3vhEfS+3fDlc/BAZiAp+43QEC/yCo5zkNoY2YaKvNkOaFr/6wCFgFH1kuYQM5pMNi0Tg8koiIemtw==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/ofetch/-/ofetch-1.4.1.tgz",
+      "integrity": "sha512-QZj2DfGplQAr2oj9KzceK9Hwz6Whxazmn85yYeVuS3u9XTMOGMRx0kO95MQ+vLsj/S/NwBDMMLU5hpxvI6Tklw==",
+      "license": "MIT",
       "dependencies": {
         "destr": "^2.0.3",
-        "node-fetch-native": "^1.6.3",
-        "ufo": "^1.5.3"
+        "node-fetch-native": "^1.6.4",
+        "ufo": "^1.5.4"
       }
     },
     "node_modules/ohash": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/ohash/-/ohash-1.1.3.tgz",
-      "integrity": "sha512-zuHHiGTYTA1sYJ/wZN+t5HKZaH23i4yI1HMwbuXm24Nid7Dv0KcuRlKoNKS9UNfAVSBlnGLcuQrnOKWOZoEGaw=="
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/ohash/-/ohash-1.1.4.tgz",
+      "integrity": "sha512-FlDryZAahJmEF3VR3w1KogSEdWX3WhA5GPakFx4J81kEAiHyLMpdLLElS8n8dfNadMgAne/MywcvmogzscVt4g==",
+      "license": "MIT"
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
@@ -14398,9 +14885,10 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.2.tgz",
-      "integrity": "sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw=="
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "license": "MIT"
     },
     "node_modules/path-type": {
       "version": "5.0.0",
@@ -14628,13 +15116,13 @@
       }
     },
     "node_modules/pkg-types": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.2.0.tgz",
-      "integrity": "sha512-+ifYuSSqOQ8CqP4MbZA5hDpb97n3E8SVWdJe+Wms9kj745lmd3b7EZJiqvmLwAlmRfjrI7Hi5z3kdBJ93lFNPA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.2.1.tgz",
+      "integrity": "sha512-sQoqa8alT3nHjGuTjuKgOnvjo4cljkufdtLMnO2LBP/wRwuDlo1tkaEdMxCRhyGRPacv/ztlZgDPm2b7FAmEvw==",
       "license": "MIT",
       "dependencies": {
-        "confbox": "^0.1.7",
-        "mlly": "^1.7.1",
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.2",
         "pathe": "^1.1.2"
       }
     },
@@ -15318,6 +15806,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/printable-characters": {
+      "version": "1.0.42",
+      "resolved": "https://registry.npmjs.org/printable-characters/-/printable-characters-1.0.42.tgz",
+      "integrity": "sha512-dKp+C4iXWK4vVYZmYSd0KBH5F/h1HoZRsbJ82AVKRO3PEo8L4lBS/vLwhVtpwwuYcoIsVY+1JYKR268yn480uQ==",
+      "dev": true,
+      "license": "Unlicense"
     },
     "node_modules/proc-log": {
       "version": "4.2.0",
@@ -16037,6 +16532,16 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/resolve.exports": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.2.tgz",
+      "integrity": "sha512-X2UW6Nw3n/aMgDVy+0rSqgHlv39WZAlZrXCdnbyEiKm17DSqHX4MmQMaST3FbeWR5FTuRcUwYAziZajji0Y7mg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/retry": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
@@ -16148,6 +16653,46 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rollup-plugin-inject": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-inject/-/rollup-plugin-inject-3.0.2.tgz",
+      "integrity": "sha512-ptg9PQwzs3orn4jkgXJ74bfs5vYz1NCZlSQMBUA0wKcGp5i5pA1AO3fOUEte8enhGUC+iapTCzEWw2jEFFUO/w==",
+      "deprecated": "This package has been deprecated and is no longer maintained. Please use @rollup/plugin-inject.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "estree-walker": "^0.6.1",
+        "magic-string": "^0.25.3",
+        "rollup-pluginutils": "^2.8.1"
+      }
+    },
+    "node_modules/rollup-plugin-inject/node_modules/estree-walker": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
+      "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rollup-plugin-inject/node_modules/magic-string": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sourcemap-codec": "^1.4.8"
+      }
+    },
+    "node_modules/rollup-plugin-node-polyfills": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-node-polyfills/-/rollup-plugin-node-polyfills-0.2.1.tgz",
+      "integrity": "sha512-4kCrKPTJ6sK4/gLL/U5QzVT8cxJcofO0OU74tnB19F40cmuAKSzH5/siithxlofFEjwvw1YAhPmbvGNA6jEroA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "rollup-plugin-inject": "^3.0.0"
+      }
+    },
     "node_modules/rollup-plugin-visualizer": {
       "version": "5.12.0",
       "resolved": "https://registry.npmjs.org/rollup-plugin-visualizer/-/rollup-plugin-visualizer-5.12.0.tgz",
@@ -16172,6 +16717,23 @@
           "optional": true
         }
       }
+    },
+    "node_modules/rollup-pluginutils": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
+      "integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "estree-walker": "^0.6.1"
+      }
+    },
+    "node_modules/rollup-pluginutils/node_modules/estree-walker": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
+      "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/rollup/node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.18.0",
@@ -16299,6 +16861,20 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/scule/-/scule-1.3.0.tgz",
       "integrity": "sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g=="
+    },
+    "node_modules/selfsigned": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.4.1.tgz",
+      "integrity": "sha512-th5B4L2U+eGLq1TVh7zNRGBapioSORUeymIydxgFpwww9d2qyKvtuPU2jJuHvYAwwqi2Y596QBL3eEqcPEYL8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node-forge": "^1.3.0",
+        "node-forge": "^1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/semver": {
       "version": "7.6.3",
@@ -16821,6 +17397,17 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/stacktracey": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/stacktracey/-/stacktracey-2.1.8.tgz",
+      "integrity": "sha512-Kpij9riA+UNg7TnphqjH7/CzctQ/owJGNbFkfEeve4Z4uxT5+JapVLFXcsurIfN34gnTWZNJ/f7NMG0E8JDzTw==",
+      "dev": true,
+      "license": "Unlicense",
+      "dependencies": {
+        "as-table": "^1.0.36",
+        "get-source": "^2.0.12"
+      }
+    },
     "node_modules/standard-as-callback": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
@@ -16838,6 +17425,17 @@
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.7.0.tgz",
       "integrity": "sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg=="
+    },
+    "node_modules/stoppable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
+      "integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4",
+        "npm": ">=6"
+      }
     },
     "node_modules/streamx": {
       "version": "2.18.0",
@@ -17806,15 +18404,16 @@
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/unenv": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/unenv/-/unenv-1.9.0.tgz",
-      "integrity": "sha512-QKnFNznRxmbOF1hDgzpqrlIf6NC5sbZ2OJ+5Wl3OX8uM+LUJXbj4TXvLJCtwbPTmbMHCLIz6JLKNinNsMShK9g==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-1.10.0.tgz",
+      "integrity": "sha512-wY5bskBQFL9n3Eca5XnhH6KbUo/tfvkwm9OpcdCvLaeA7piBNbavbOKJySEwQ1V0RH6HvNlSAFRTpvTqgKRQXQ==",
+      "license": "MIT",
       "dependencies": {
         "consola": "^3.2.3",
-        "defu": "^6.1.3",
+        "defu": "^6.1.4",
         "mime": "^3.0.0",
-        "node-fetch-native": "^1.6.1",
-        "pathe": "^1.1.1"
+        "node-fetch-native": "^1.6.4",
+        "pathe": "^1.1.2"
       }
     },
     "node_modules/unenv/node_modules/mime": {
@@ -18090,35 +18689,36 @@
       }
     },
     "node_modules/unstorage": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/unstorage/-/unstorage-1.10.2.tgz",
-      "integrity": "sha512-cULBcwDqrS8UhlIysUJs2Dk0Mmt8h7B0E6mtR+relW9nZvsf/u4SkAYyNliPiPW7XtFNb5u3IUMkxGxFTTRTgQ==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/unstorage/-/unstorage-1.13.0.tgz",
+      "integrity": "sha512-nrUXbFW00q8SqrJSgyyZ7OhNK1ugAF1wmOJu4V90Ww0V5b3CJSlcZt/V6D+2DktCuBZAoIcSIsn6gifwi8JgnQ==",
+      "license": "MIT",
       "dependencies": {
         "anymatch": "^3.1.3",
-        "chokidar": "^3.6.0",
+        "chokidar": "^4.0.1",
+        "citty": "^0.1.6",
         "destr": "^2.0.3",
-        "h3": "^1.11.1",
-        "listhen": "^1.7.2",
-        "lru-cache": "^10.2.0",
-        "mri": "^1.2.0",
-        "node-fetch-native": "^1.6.2",
-        "ofetch": "^1.3.3",
-        "ufo": "^1.4.0"
+        "h3": "^1.13.0",
+        "listhen": "^1.9.0",
+        "lru-cache": "^10.4.3",
+        "node-fetch-native": "^1.6.4",
+        "ofetch": "^1.4.1",
+        "ufo": "^1.5.4"
       },
       "peerDependencies": {
-        "@azure/app-configuration": "^1.5.0",
-        "@azure/cosmos": "^4.0.0",
+        "@azure/app-configuration": "^1.7.0",
+        "@azure/cosmos": "^4.1.1",
         "@azure/data-tables": "^13.2.2",
-        "@azure/identity": "^4.0.1",
-        "@azure/keyvault-secrets": "^4.8.0",
-        "@azure/storage-blob": "^12.17.0",
-        "@capacitor/preferences": "^5.0.7",
-        "@netlify/blobs": "^6.5.0 || ^7.0.0",
-        "@planetscale/database": "^1.16.0",
-        "@upstash/redis": "^1.28.4",
+        "@azure/identity": "^4.5.0",
+        "@azure/keyvault-secrets": "^4.9.0",
+        "@azure/storage-blob": "^12.25.0",
+        "@capacitor/preferences": "^6.0.2",
+        "@netlify/blobs": "^6.5.0 || ^7.0.0 || ^8.1.0",
+        "@planetscale/database": "^1.19.0",
+        "@upstash/redis": "^1.34.3",
         "@vercel/kv": "^1.0.1",
         "idb-keyval": "^6.2.1",
-        "ioredis": "^5.3.2"
+        "ioredis": "^5.4.1"
       },
       "peerDependenciesMeta": {
         "@azure/app-configuration": {
@@ -18162,12 +18762,38 @@
         }
       }
     },
-    "node_modules/unstorage/node_modules/lru-cache": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.2.tgz",
-      "integrity": "sha512-9hp3Vp2/hFQUiIwKo8XCeFVnrg8Pk3TYNPIR7tJADKi5YfcF7vEaK7avFHTlSy3kOKYaJQaalfEo6YuXdceBOQ==",
+    "node_modules/unstorage/node_modules/chokidar": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.1.tgz",
+      "integrity": "sha512-n8enUVCED/KVRQlab1hr3MVpcVMvxtZjmEa956u+4YijlmQED223XMSYj2tLuKvr4jcCTzNNMpQDUer72MMmzA==",
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
       "engines": {
-        "node": "14 || >=16.14"
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/unstorage/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
+    "node_modules/unstorage/node_modules/readdirp": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.0.2.tgz",
+      "integrity": "sha512-yDMz9g+VaZkqBYS/ozoBJwaBhTbZo3UNYQHNRw1D3UFQB8oHB4uS/tAODO+ZLjGWmUbKnIlOWO+aaIiAxrUWHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/untun": {
@@ -19322,6 +19948,528 @@
         "workbox-core": "7.1.0"
       }
     },
+    "node_modules/workerd": {
+      "version": "1.20241022.0",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20241022.0.tgz",
+      "integrity": "sha512-jyGXsgO9DRcJyx6Ovv7gUyDPc3UYC2i/E0p9GFUg6GUzpldw4Y93y9kOmdfsOnKZ3+lY53veSiUniiBPE6Q2NQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20241022.0",
+        "@cloudflare/workerd-darwin-arm64": "1.20241022.0",
+        "@cloudflare/workerd-linux-64": "1.20241022.0",
+        "@cloudflare/workerd-linux-arm64": "1.20241022.0",
+        "@cloudflare/workerd-windows-64": "1.20241022.0"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "3.84.1",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-3.84.1.tgz",
+      "integrity": "sha512-w27/QpIk2qz6aMIVi9T8cDcXMvh/RXjcL+vf4o5J2GpQAE4U7wTCNHyaY9H3oTJWRN97KqCAEbiHBNtTKoUJEw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.3.4",
+        "@cloudflare/workers-shared": "0.7.0",
+        "@esbuild-plugins/node-globals-polyfill": "^0.2.3",
+        "@esbuild-plugins/node-modules-polyfill": "^0.2.2",
+        "blake3-wasm": "^2.1.5",
+        "chokidar": "^3.5.3",
+        "date-fns": "^4.1.0",
+        "esbuild": "0.17.19",
+        "itty-time": "^1.0.6",
+        "miniflare": "3.20241022.0",
+        "nanoid": "^3.3.3",
+        "path-to-regexp": "^6.3.0",
+        "resolve": "^1.22.8",
+        "resolve.exports": "^2.0.2",
+        "selfsigned": "^2.0.1",
+        "source-map": "^0.6.1",
+        "unenv": "npm:unenv-nightly@2.0.0-20241024-111401-d4156ac",
+        "workerd": "1.20241022.0",
+        "xxhash-wasm": "^1.0.1"
+      },
+      "bin": {
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=16.17.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^4.20241022.0"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-arm": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.19.tgz",
+      "integrity": "sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.19.tgz",
+      "integrity": "sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/android-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.19.tgz",
+      "integrity": "sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.19.tgz",
+      "integrity": "sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/darwin-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.19.tgz",
+      "integrity": "sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.19.tgz",
+      "integrity": "sha512-pBwbc7DufluUeGdjSU5Si+P3SoMF5DQ/F/UmTSb8HXO80ZEAJmrykPyzo1IfNbAoaqw48YRpv8shwd1NoI0jcQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.19.tgz",
+      "integrity": "sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-arm": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.19.tgz",
+      "integrity": "sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.19.tgz",
+      "integrity": "sha512-ct1Tg3WGwd3P+oZYqic+YZF4snNl2bsnMKRkb3ozHmnM0dGWuxcPTTntAF6bOP0Sp4x0PjSF+4uHQ1xvxfRKqg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-ia32": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.19.tgz",
+      "integrity": "sha512-w4IRhSy1VbsNxHRQpeGCHEmibqdTUx61Vc38APcsRbuVgK0OPEnQ0YD39Brymn96mOx48Y2laBQGqgZ0j9w6SQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-loong64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.19.tgz",
+      "integrity": "sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.19.tgz",
+      "integrity": "sha512-LKJltc4LVdMKHsrFe4MGNPp0hqDFA1Wpt3jE1gEyM3nKUvOiO//9PheZZHfYRfYl6AwdTH4aTcXSqBerX0ml4A==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.19.tgz",
+      "integrity": "sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.19.tgz",
+      "integrity": "sha512-FC3nUAWhvFoutlhAkgHf8f5HwFWUL6bYdvLc/TTuxKlvLi3+pPzdZiFKSWz/PF30TB1K19SuCxDTI5KcqASJqA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-s390x": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.19.tgz",
+      "integrity": "sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/linux-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.19.tgz",
+      "integrity": "sha512-68ngA9lg2H6zkZcyp22tsVt38mlhWde8l3eJLWkyLrp4HwMUr3c1s/M2t7+kHIhvMjglIBrFpncX1SzMckomGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.19.tgz",
+      "integrity": "sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.19.tgz",
+      "integrity": "sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/sunos-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.19.tgz",
+      "integrity": "sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-arm64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.19.tgz",
+      "integrity": "sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-ia32": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.19.tgz",
+      "integrity": "sha512-eggDKanJszUtCdlVs0RB+h35wNlb5v4TWEkq4vZcmVt5u/HiDZrTXe2bWFQUez3RgNHwx/x4sk5++4NSSicKkw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/wrangler/node_modules/@esbuild/win32-x64": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.19.tgz",
+      "integrity": "sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/wrangler/node_modules/esbuild": {
+      "version": "0.17.19",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.19.tgz",
+      "integrity": "sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/android-arm": "0.17.19",
+        "@esbuild/android-arm64": "0.17.19",
+        "@esbuild/android-x64": "0.17.19",
+        "@esbuild/darwin-arm64": "0.17.19",
+        "@esbuild/darwin-x64": "0.17.19",
+        "@esbuild/freebsd-arm64": "0.17.19",
+        "@esbuild/freebsd-x64": "0.17.19",
+        "@esbuild/linux-arm": "0.17.19",
+        "@esbuild/linux-arm64": "0.17.19",
+        "@esbuild/linux-ia32": "0.17.19",
+        "@esbuild/linux-loong64": "0.17.19",
+        "@esbuild/linux-mips64el": "0.17.19",
+        "@esbuild/linux-ppc64": "0.17.19",
+        "@esbuild/linux-riscv64": "0.17.19",
+        "@esbuild/linux-s390x": "0.17.19",
+        "@esbuild/linux-x64": "0.17.19",
+        "@esbuild/netbsd-x64": "0.17.19",
+        "@esbuild/openbsd-x64": "0.17.19",
+        "@esbuild/sunos-x64": "0.17.19",
+        "@esbuild/win32-arm64": "0.17.19",
+        "@esbuild/win32-ia32": "0.17.19",
+        "@esbuild/win32-x64": "0.17.19"
+      }
+    },
+    "node_modules/wrangler/node_modules/nanoid": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/wrangler/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrangler/node_modules/unenv": {
+      "name": "unenv-nightly",
+      "version": "2.0.0-20241024-111401-d4156ac",
+      "resolved": "https://registry.npmjs.org/unenv-nightly/-/unenv-nightly-2.0.0-20241024-111401-d4156ac.tgz",
+      "integrity": "sha512-xJO1hfY+Te+/XnfCYrCbFbRcgu6XEODND1s5wnVbaBCkuQX7JXF7fHEXPrukFE2j8EOH848P8QN19VO47XN8hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defu": "^6.1.4",
+        "ohash": "^1.1.4",
+        "pathe": "^1.1.2",
+        "ufo": "^1.5.4"
+      }
+    },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -19449,6 +20597,13 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/xxhash-wasm": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-1.0.2.tgz",
+      "integrity": "sha512-ibF0Or+FivM9lNrg+HGJfVX8WJqgo+kCLDc4vx6xMeTce7Aj+DLttKbxxRR/gNLSAelRc1omAPlJ77N/Jem07A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -19517,6 +20672,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/youch": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-3.3.4.tgz",
+      "integrity": "sha512-UeVBXie8cA35DS6+nBkls68xaBBXCye0CNznrhszZjTbRVnJKQuNsyLKBTTL4ln1o1rh2PKtv35twV7irj5SEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^0.7.1",
+        "mustache": "^4.2.0",
+        "stacktracey": "^2.1.8"
+      }
+    },
     "node_modules/zhead": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/zhead/-/zhead-2.2.4.tgz",
@@ -19536,6 +20703,15 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@aws-sdk/client-s3": "^3.540.0",
     "@hotjar/browser": "^1.0.9",
     "@nuxt/ui": "npm:@nuxt/ui-edge@latest",
+    "@nuxthub/core": "^0.8.4",
     "@pinia/nuxt": "^0.5.1",
     "@tiptap/extension-font-family": "^2.4.0",
     "@tiptap/extension-highlight": "^2.3.0",
@@ -58,11 +59,12 @@
     "@tauri-apps/cli": "^1.5.14",
     "@types/socket.io-client": "^3.0.0",
     "typescript": "^5.4.5",
-    "vue-tsc": "^2.0.16"
+    "vue-tsc": "^2.0.16",
+    "wrangler": "^3.84.1"
   },
   "optionalDependencies": {
-    "@rollup/rollup-linux-x64-gnu": "4.9.5",
-    "@esbuild/linux-x64": "0.24.0"
+    "@esbuild/linux-x64": "0.24.0",
+    "@rollup/rollup-linux-x64-gnu": "4.9.5"
   },
   "overrides": {
     "sharp": "0.32.6",

--- a/pages/signup/index.vue
+++ b/pages/signup/index.vue
@@ -252,7 +252,18 @@ const passwordValid = computed(() => {
   return regex.test(password.value)
 })
 
+const getChurch = async () => {
+  if (user.value?.churchId) {
+    const { data } = await useAPIFetch(`/church/${user.value?.churchId}`)
+    authStore.setChurch(data.value)
+    navigateTo("/")
+  }
+}
+
 onMounted(() => {
+  if (route.query.registerChurch) {
+    getChurch()
+  }
   setTimeout(() => {
     useToast().add({
       title: "Still not convinced?",

--- a/store/app.ts
+++ b/store/app.ts
@@ -79,6 +79,7 @@ export const useAppStore = defineStore('app', {
         bannerVisible: true as boolean,
         bibleVersions: bibleVersionObjects as Array<any>, // Check app.vue for bible versions array in a list
         activeSocket: null as WebSocket | null,
+        mainDisplayLabel: '',
         // activeLiveWindows: [] as any[]
       },
       // Undo/Redo stacks
@@ -226,6 +227,9 @@ export const useAppStore = defineStore('app', {
     },
     setActiveSocket(socket: WebSocket) {
       this.currentState.activeSocket = socket
+    },
+    setMainDisplayLabel(label: string) {
+      this.currentState.mainDisplayLabel = label
     },
     // setActiveLiveWindows(windows: any[]) {
     //   this.activeLiveWindows = JSON.stringify(windows)

--- a/store/app.ts
+++ b/store/app.ts
@@ -66,6 +66,8 @@ export const useAppStore = defineStore('app', {
               backgroundVideoKey: '/video-bg-4.mp4'
             }
           },
+          animations: true,
+          transitionInterval: 0.7,
           slideStyles: { blur: 0.5, brightness: 50, linesPerSlide: 4, alignment: 'center' } as SlideStyle,
           bibleVersions: [] as Array<any>, // Check app.vue for bible versions array in a list
         },
@@ -233,6 +235,12 @@ export const useAppStore = defineStore('app', {
     },
     setLinesPerSlide(lines: number) {
       this.currentState.settings = { ...this.currentState.settings, slideStyles: { ...this.currentState.settings.slideStyles, linesPerSlide: lines } }
+    },
+    setAnimations(animations: boolean) {
+      this.currentState.settings = { ...this.currentState.settings, animations: animations }
+    },
+    setTransitionInterval(interval: number) {
+      this.currentState.settings = { ...this.currentState.settings, transitionInterval: interval }
     },
     // setActiveLiveWindows(windows: any[]) {
     //   this.activeLiveWindows = JSON.stringify(windows)

--- a/store/app.ts
+++ b/store/app.ts
@@ -231,6 +231,9 @@ export const useAppStore = defineStore('app', {
     setMainDisplayLabel(label: string) {
       this.currentState.mainDisplayLabel = label
     },
+    setLinesPerSlide(lines: number) {
+      this.currentState.settings = { ...this.currentState.settings, slideStyles: { ...this.currentState.settings.slideStyles, linesPerSlide: lines } }
+    },
     // setActiveLiveWindows(windows: any[]) {
     //   this.activeLiveWindows = JSON.stringify(windows)
     // },


### PR DESCRIPTION
- Enforced one church account per user.
- Fixed flickering backdrop issue on slide change.
- Added animation settings for slides.
- Added app-wide setting for number of lines per slide.
- Added storage settings, indicator including local data deletion.
- Fixed an issue affecting offline access functionality.
- Refined display and screen settings, including media slide background and content background fill type on Edit Content Pane.
- Resolved an issue with a wrong error message on the /verify page.
- Fixed a bug causing perpetual slide retrieval on schedule change.
- Updated Bible versions download process and improved sensitive information handling.
- Implemented auto-redirect to home page upon app update.
- Switched to NuxtHub for better uptime in Nigeria region.
