### PR TITLE
feat/V0.9.3: Multiple verses per Bible slide, livestream banners, fixes, and more

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -39,7 +39,7 @@ const appStore = useAppStore()
 nuxtApp.provide("emitter", emitter)
 appStore.setEmitter(emitter)
 
-const appVersion = ref<string>("0.9.2")
+const appVersion = ref<string>("0.9.3")
 
 // const registerServiceWorker = async () => {
 //   if ("serviceWorker" in navigator) {

--- a/components/AddAlert.vue
+++ b/components/AddAlert.vue
@@ -129,6 +129,18 @@ const bgColor = ref<string>("#a855f7")
 const toast = useToast()
 const emit = defineEmits(["go-home"])
 
+watch(
+  currentState,
+  () => {
+    if (currentState.value?.activeAlert?.id === props.alert?.id) {
+      sendAlertToWebsocket(props.alert)
+    } else if (currentState.value.activeAlert === null) {
+      removeAlertFromWebsocket()
+    }
+  },
+  { deep: true }
+)
+
 const deleteAlert = (alert: Alert) => {
   const tempAlerts = [...currentState.value?.alerts]
   const newAlertIndex = tempAlerts.findIndex((a) => a.id === alert.id)
@@ -157,9 +169,29 @@ const addAlert = async () => {
     }
     appStore.setAlerts([...currentState.value?.alerts, alert])
     appStore.setActiveAlert(alert)
+
     toast.add({ icon: "i-bx-send", title: "Alert sent to live" })
     emit("go-home")
   }
+}
+
+const sendAlertToWebsocket = (alert: Alert) => {
+  const socket = useNuxtApp().$socket as WebSocket
+  socket.send(
+    JSON.stringify({
+      action: "add-alert",
+      data: alert,
+    })
+  )
+}
+
+const removeAlertFromWebsocket = () => {
+  const socket = useNuxtApp().$socket as WebSocket
+  socket.send(
+    JSON.stringify({
+      action: "remove-alert",
+    })
+  )
 }
 </script>
 

--- a/components/ChangelogModal.vue
+++ b/components/ChangelogModal.vue
@@ -59,13 +59,11 @@ defineProps<{
 }>()
 
 const emitter = useNuxtApp().$emitter as Emitter<any>
-const changelog = `- Added & Improved WebSocket functionality to reconnect on failure and upgraded to secure WebSocket (WSS).
-- Enhanced shortcuts to support full-screen mode.
-- Resolved display settings issues, including support for monitors without labels.
-- Integrated PostHog for improved user feedback and product experience.
-- Added keyboard shortcut to switch live display slides.
-- Introduced a new “Go Live” button with livestreaming options.
-- Updated livestream pages to support WebSocket integration.`
+const changelog = `- Enabled multiple verses per Bible slide.
+- Increased timeout and retries for WebSocket connections.
+- Added support for uploading slide background images.
+- Implemented alerts and banners in livestream mode.
+- Fixed livestream to recognize new slides by default.`
 
 const appStore = useAppStore()
 

--- a/components/EditLiveContent.vue
+++ b/components/EditLiveContent.vue
@@ -343,7 +343,9 @@ const animatedSlides = computed(() => {
 
 const nextVerse = computed(() => {
   if (props.slide?.type === slideTypes.bible) {
-    const tempVerse = Number(verse.value?.split(":")?.[1]) + 1
+    const tempVerse = verse.value?.split(":")?.[1]?.includes("-")
+      ? Number(verse.value?.split(":")?.[1]?.split("-")?.[1]) + 1
+      : Number(verse.value?.split(":")?.[1]) + 1
     return `${verse.value?.split(":")?.[0]}:${tempVerse}`
   }
   return `Verse ${Number(verse.value?.split(" ")?.[1]) + 1}`
@@ -351,7 +353,9 @@ const nextVerse = computed(() => {
 
 const previousVerse = computed(() => {
   if (props.slide?.type === slideTypes.bible) {
-    const tempVerse = Number(verse.value?.split(":")?.[1]) - 1
+    const tempVerse = verse.value?.split(":")?.[1]?.includes("-")
+      ? Number(verse.value?.split(":")?.[1]?.split("-")?.[0]) - 1
+      : Number(verse.value?.split(":")?.[1]) - 1
     return `${verse.value?.split(":")?.[0]}:${tempVerse < 1 ? 1 : tempVerse}`
   }
   return `Verse ${Number(verse.value?.split(" ")?.[1]) - 1}`

--- a/components/PreviewContent.vue
+++ b/components/PreviewContent.vue
@@ -152,6 +152,9 @@ watch(
         (slide) => slide.id === activeSlide.value?.id
       )
     }
+    if (activeSlide.value) {
+      sendNewSlideToWebsocket(activeSlide.value)
+    }
   },
   { deep: true, immediate: true }
 )
@@ -305,6 +308,17 @@ emitter.on("promote-active-slide-live", () => {
     })
   }
 })
+
+const sendNewSlideToWebsocket = useDebounceFn((slide: Slide) => {
+  // console.log("activeSlide", slide)
+  const socket = useNuxtApp().$socket as WebSocket
+  socket.send(
+    JSON.stringify({
+      action: "new-slide",
+      data: slide,
+    })
+  )
+}, 500)
 
 const preSlideCreation = (): Slide => {
   const tempSlide: Slide = {

--- a/components/PreviewVerses.vue
+++ b/components/PreviewVerses.vue
@@ -18,11 +18,8 @@
       :key="`verse-${index}`"
       :id="
         slide?.type === slideTypes.bible
-          ? `${(bibleChapter + '-' + verseTemp?.verse)
-              ?.toLowerCase()
-              .replaceAll(' ', '-')
-              .replaceAll(':', '-')}`
-          : `${verse?.toLowerCase().replaceAll(' ', '-').replace(/\d+/g, '')}`
+          ? convertStringToSlug(`${bibleChapter + '-' + verseTemp?.verse}`)
+          : convertStringToSlug(verse).replace(/\d+/g, '')
       "
       class="item rounded-none flex px-4 py-3 justify-start border-t border-primary-200 dark:border-primary-950 hover:bg-primary-200 dark:hover:bg-primary-600 cursor-pointer w-[100%] text-left items-start font-normal text-black dark:text-white"
       :class="{
@@ -106,10 +103,7 @@ watch(
       const activeVerse =
         props.slide.type === slideTypes.bible
           ? versesPreview.value?.querySelector(
-              `#${props.verse
-                ?.toLowerCase()
-                .replaceAll(" ", "-")
-                .replaceAll(":", "-")}`
+              `#${convertStringToSlug(props.verse)}`
             )
           : versesPreview.value?.querySelector(
               `#${props.verse?.replace(" ", "-")?.toLowerCase()}`
@@ -150,6 +144,16 @@ watch(
 //   }
 //   return []
 // })
+
+const convertStringToSlug = (str: string) => {
+  return str
+    .toLowerCase()
+    .replaceAll("1 ", "one-")
+    .replaceAll("2 ", "two-")
+    .replaceAll("3 ", "three-")
+    .replaceAll(" ", "-")
+    .replaceAll(":", "-")
+}
 
 const getNumberRange = (number: number, rangeBound = 20) => {
   const lowerRange = []

--- a/components/QuickActions.vue
+++ b/components/QuickActions.vue
@@ -286,6 +286,12 @@ emitter.on("remove-alert", () => {
     icon: "i-bx-trash",
     title: "Active alert has been removed",
   })
+  const socket = useNuxtApp().$socket as WebSocket
+  socket.send(
+    JSON.stringify({
+      action: "remove-alert",
+    })
+  )
 })
 
 emitter.on("add-song", () => {

--- a/pages/livestream/[schedule_id].vue
+++ b/pages/livestream/[schedule_id].vue
@@ -274,8 +274,10 @@ const connectWebSocket = async () => {
       case "live-slide":
         const tempSlide = updateBlobBackgroundURl(data)
         liveSlide.value = tempSlide
+        // console.log("liveSlide", liveSlide.value)
         break
       case "new-slide":
+        slides.value.push(data)
         break
       case "update-slide":
         const slideId = data?._id

--- a/pages/livestream/[schedule_id].vue
+++ b/pages/livestream/[schedule_id].vue
@@ -288,6 +288,12 @@ const connectWebSocket = async () => {
           slideData
         )
         break
+      case "add-alert":
+        appStore.setActiveAlert(data)
+        break
+      case "remove-alert":
+        appStore.setActiveAlert(null)
+        break
       case "updated-slides":
         break
       default:

--- a/pages/livestream/[schedule_id].vue
+++ b/pages/livestream/[schedule_id].vue
@@ -114,7 +114,7 @@ const cachedVideosURLs = ref<BackgroundVideo[]>()
 const isOfflineToastOpen = ref<boolean>(false)
 const db = useIndexedDB()
 
-const MAX_RETRIES = 10
+const MAX_RETRIES = 30
 let retryCount = 0
 
 useHead({
@@ -306,7 +306,7 @@ const connectWebSocket = async () => {
     console.log("websocket connection closed")
     if (retryCount < MAX_RETRIES && isAppOnline.value) {
       retryCount++
-      const retryDelay = retryCount * 31000
+      const retryDelay = retryCount * 3000
       console.log(`Reconnecting in ${retryDelay / 1000} seconds...`)
       setTimeout(connectWebSocket, retryDelay)
     } else {

--- a/types/index.ts
+++ b/types/index.ts
@@ -111,7 +111,7 @@ export interface Media {
   id: string
   content?: any
   remoteUrl?: string
-  data?: ArrayBuffer
+  data?: ArrayBuffer | string
   createdAt?: string
   updatedAt?: string
 }


### PR DESCRIPTION
- Enabled multiple verses per Bible slide.
- Increased timeout and retries for WebSocket connections.
- Added support for uploading slide background images.
- Implemented alerts and banners in livestream mode.
- Fixed livestream to recognize new slides by default.