### PR TITLE
feat: hands-free sermon transcription with auto bible slide + live projection

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -42,7 +42,7 @@ if (nuxtApp.$emitter) {
 }
 appStore.setEmitter(emitter)
 
-const appVersion = ref<string>("v0.50.2-beta")
+const appVersion = ref<string>("v0.50.3-beta")
 
 const warmOfflineRoutes = async () => {
   await Promise.allSettled([

--- a/app/components/PreviewContent.vue
+++ b/app/components/PreviewContent.vue
@@ -1014,22 +1014,23 @@ const updateSlideOnline = useThrottleFn(
       })
 
       // UPDATE OVER HTTP for persistence
+      let data: any, error: any
       try {
-        const { data, error } = await useAPIFetch(
+        ;({ data, error } = await useAPIFetch(
           `/church/${churchId}/schedules/${appStore.currentState.activeSchedule?._id}/slides/${slide?._id}`,
           {
             method: "PUT",
             body: tempSlide,
           }
-        )
+        ))
       } catch (err) {
         console.error("Failed to update slide online:", err)
       }
-      if (!error.value) {
+      if (!error?.value) {
         appStore.setLastSynced(new Date().toISOString())
         return data.value
       } else {
-        throw new Error(error.value?.message)
+        throw new Error(error?.value?.message)
       }
     }
   },

--- a/app/components/PreviewContent.vue
+++ b/app/components/PreviewContent.vue
@@ -430,48 +430,44 @@ emitter.on("new-bible", async (data: string) => {
 })
 
 emitter.on("update-or-create-bible", async (data: string) => {
-  if (data) {
-    // Find any existing Bible slide (prefer the live one)
-    const existingBibleSlide =
-      slides.value?.find(
-        (s: Slide) =>
-          s.type === slideTypes.bible &&
-          s.id === currentState.value?.liveSlideId
-      ) || slides.value?.find((s: Slide) => s.type === slideTypes.bible)
+  if (!data) return
 
-    const scripture = await useScripture(data)
-    if (scripture) {
-      if (existingBibleSlide) {
-        // Update the existing Bible slide
-        const updatedSlide = await gotoVerse(
-          existingBibleSlide,
-          scripture.label,
-          scripture.version || "KJV"
-        )
-        if (updatedSlide) {
-          const slideIndex = slides.value.findIndex(
-            (s: Slide) => s.id === updatedSlide.id
-          )
-          slides.value.splice(slideIndex, 1, updatedSlide)
-          makeSlideActive(updatedSlide, { goLive: true, newlyCreated: false })
-          updateLiveOutput(updatedSlide)
-          updateSlideOnline(updatedSlide)
-        }
-      } else {
-        // No existing Bible slide - create a new one
-        const newSlide = createBibleSlide(scripture)
-        slides.value?.push(newSlide)
-        makeSlideActive(newSlide, {
-          goLive: true,
-          newlyCreated: true,
-        })
-        // Broadcast slide creation immediately for real-time sync
-        broadcastSlideCreated(newSlide)
-        uploadOfflineSlides()
-      }
-      appStore.setRecentBibleSearches(data)
+  // Find any existing Bible slide (prefer the live one)
+  const existingBibleSlide =
+    slides.value?.find(
+      (s: Slide) =>
+        s.type === slideTypes.bible &&
+        s.id === currentState.value?.liveSlideId
+    ) || slides.value?.find((s: Slide) => s.type === slideTypes.bible)
+
+  // Resolve the shortLabel to a scripture object — needed for both paths
+  // to get the human-readable label (e.g. "Genesis 28:19") that gotoVerse expects.
+  const scripture = await useScripture(data)
+  if (!scripture) return
+
+  if (existingBibleSlide) {
+    const updatedSlide = await gotoVerse(
+      existingBibleSlide,
+      scripture.label,
+      scripture.version || "KJV"
+    )
+    if (updatedSlide) {
+      const slideIndex = slides.value.findIndex(
+        (s: Slide) => s.id === updatedSlide.id
+      )
+      slides.value.splice(slideIndex, 1, updatedSlide)
+      makeSlideActive(updatedSlide, { goLive: true, newlyCreated: false })
+      updateLiveOutput(updatedSlide)
+      updateSlideOnline(updatedSlide)
     }
+  } else {
+    const newSlide = createBibleSlide(scripture)
+    slides.value?.push(newSlide)
+    makeSlideActive(newSlide, { goLive: true, newlyCreated: true })
+    broadcastSlideCreated(newSlide)
+    uploadOfflineSlides()
   }
+  appStore.setRecentBibleSearches(data)
 })
 
 emitter.on("new-bible-whole-search", async (data: string) => {

--- a/app/components/QuickActions.vue
+++ b/app/components/QuickActions.vue
@@ -78,7 +78,19 @@
         class="actions-ctn mt-2 overflow-y-auto max-h-[calc(100vh-190px)]"
         ref="actionsContainer"
       >
+        <!-- Skeleton loader while IndexedDB is hydrating -->
+        <template v-if="loading">
+          <div
+            v-for="i in 20"
+            :key="i"
+            class="flex gap-3 p-2 py-2 dark:border-primary-950"
+          >
+            <USkeleton class="h-16 w-full rounded" />
+          </div>
+        </template>
+
         <ActionCard
+          v-else
           v-for="(action, index) in visibleActions"
           :key="action?.name"
           :action="action"
@@ -211,6 +223,7 @@ const searchInputEl = ref<{ input: HTMLInputElement }>()
 const searchInput = ref<string>("")
 const focusedActionIndex = ref<number>(0)
 const actions = ref<QuickAction[]>([])
+const loading = ref(true)
 const quickActions = ref<HTMLDivElement | null>(null)
 const actionsContainer = ref<HTMLDivElement | null>(null)
 const appStore = useAppStore()
@@ -254,6 +267,7 @@ const getAllHymns = async () => {
       }
     })
   )
+  loading.value = false
 }
 
 getAllHymns()

--- a/app/components/live/TranscriptsPanel.vue
+++ b/app/components/live/TranscriptsPanel.vue
@@ -403,6 +403,7 @@ const {
   isTeamsPlan,
   useDeepgramEngine,
   micLevel,
+  deepgramScriptureResults,
 } = useSermonTranscription()
 
 // ── Tabs ───────────────────────────────────────────────────────────────────
@@ -419,16 +420,26 @@ watch(isTranscribing, (val) => {
 })
 
 // ── Scripture search ───────────────────────────────────────────────────────
+// On the Deepgram path the server pushes scripture results over the same WS
+// connection — no HTTP search needed. The Web Speech (free) path still uses
+// the HTTP fallback because there's no server connection to push from.
 const {
-  results: scriptureResults,
+  results: httpScriptureResults,
   isSearching: isScriptureSearching,
   debouncedSearch,
   addFromBibleReferences,
-  clearResults: clearScriptureResults,
+  clearResults: clearHttpScriptureResults,
 } = useScriptureSearch()
+
+const scriptureResults = computed(() =>
+  useDeepgramEngine.value ? deepgramScriptureResults.value : httpScriptureResults.value
+)
 
 const scriptureVisibleCount = ref(20)
 const visibleScriptureResults = computed(() =>
+  // On the Deepgram path the list is already ordered: newest batch first,
+  // backend score order within each batch. On the Web Speech path we sort
+  // by batchId then score for the same effect.
   [...scriptureResults.value]
     .sort((a, b) => b.batchId - a.batchId || b.score - a.score)
     .slice(0, scriptureVisibleCount.value)
@@ -447,16 +458,18 @@ const parsedSegmentIds = new Set<string>()
 watch(
   () => segments.value.length,
   () => {
+    // Deepgram path: server already pushed references and scriptures via WS,
+    // nothing to do here.
+    if (useDeepgramEngine.value) return
+
+    // Free / Web Speech path: locally parse and HTTP-search.
     for (const segment of segments.value) {
       if (parsedSegmentIds.has(segment.id)) continue
       parsedSegmentIds.add(segment.id)
-
-      // Use the already-parsed bible references from the segment
       if (segment.bibleReferences.length > 0)
         addFromBibleReferences(segment.bibleReferences)
     }
 
-    // Also fire the debounced backend search with the last 3 segments
     const combinedText = segments.value
       .slice(-3)
       .map((s) => s.text)
@@ -486,8 +499,11 @@ const toggleTranscription = () =>
   isTranscribing.value ? stopTranscription() : startTranscription()
 
 const handleClear = () => {
+  // `clearTranscript()` from useSermonTranscription clears both segments AND
+  // the Deepgram-path scripture results (handled inside the composable).
   clearTranscript()
-  clearScriptureResults()
+  // Also reset the HTTP-path scripture results used by the free / Web Speech path.
+  clearHttpScriptureResults()
   parsedSegmentIds.clear()
   scriptureVisibleCount.value = 20
 }

--- a/app/components/settings/DisplaySettings.vue
+++ b/app/components/settings/DisplaySettings.vue
@@ -43,7 +43,7 @@
         </UButton>
       </div>
     </div>
-    <div v-if="isTauri" class="live-window-settings flex flex-col gap-2">
+    <div class="live-window-settings flex flex-col gap-2">
       <div class="sub-header">
         <h3 class="font-medium">Live Window Settings</h3>
         <p class="text-xs opacity-50 mb-2 mt-1">
@@ -51,6 +51,7 @@
         </p>
       </div>
       <div
+        v-if="isTauri"
         class="bg-gray-100 dark:bg-gray-800 p-4 px-6 rounded-md flex justify-between items-center"
       >
         <div class="info">
@@ -70,6 +71,34 @@
                 title: value
                   ? 'Live window will open in fullscreen'
                   : 'Live window will open as resizable window',
+                icon: 'i-bx-check-circle',
+              })
+            }
+          "
+        />
+      </div>
+      <div
+        v-if="!isTauri"
+        class="bg-gray-100 dark:bg-gray-800 p-4 px-6 rounded-md flex justify-between items-center"
+      >
+        <div class="info pr-4">
+          <div class="text-sm font-semibold">
+            Close live window when this tab is closed
+          </div>
+          <div class="text-xs opacity-70 mt-1">
+            When enabled, the live output window closes automatically if you
+            close the control center tab.
+          </div>
+        </div>
+        <UToggle
+          :model-value="currentState.settings.closeLiveWindowWithOperator"
+          @update:model-value="
+            (value: boolean) => {
+              appStore.setCloseLiveWindowWithOperator(value)
+              useToast().add({
+                title: value
+                  ? 'Live window will close with this tab'
+                  : 'Live window will stay open when this tab is closed',
                 icon: 'i-bx-check-circle',
               })
             }

--- a/app/composables/useDeepgramTranscription.ts
+++ b/app/composables/useDeepgramTranscription.ts
@@ -2,7 +2,8 @@ import { ref, computed, onUnmounted } from 'vue'
 import { useAppStore } from '~/store/app'
 import { useAuthStore } from '~/store/auth'
 import type { TranscriptSegment, BibleReference } from '~/types/transcript'
-import { appWideActions } from '~/utils/constants'
+import type { ScriptureResult } from '~/composables/useScriptureSearch'
+import { appWideActions, bibleBooks } from '~/utils/constants'
 
 interface TranscriptionState {
   isTranscribing: boolean
@@ -12,12 +13,25 @@ interface TranscriptionState {
   currentTranscript: string
   remainingSeconds: number | null
   usedSeconds: number
+  // Scripture results pushed by the server over the same WS connection,
+  // so the panel can render them without a separate HTTP search.
+  scriptureResults: ScriptureResult[]
 }
 
 /**
  * Composable for Deepgram-powered real-time transcription (Teams plan only).
- * Streams microphone audio to the backend WebSocket proxy which relays to Deepgram.
- * Enforces a 60-minute-per-week limit server-side.
+ *
+ * Streams microphone audio to the backend WebSocket proxy which relays to
+ * Deepgram, then pushes back four kinds of messages over the same connection:
+ *   - transcript  (interim + final)
+ *   - references  (Bible refs parsed server-side, on each final segment)
+ *   - scriptures  (semantic scripture matches, pushed on each final segment)
+ *   - limit_reached / error
+ *
+ * Performance/reliability features:
+ *   - AudioWorklet capture (off the main thread, 32 ms chunks)
+ *   - KeepAlive frames during silence to prevent Deepgram timeouts
+ *   - Voice commands fire on interim results with a fire-once latch
  */
 export default function useDeepgramTranscription() {
   const appStore = useAppStore()
@@ -33,98 +47,161 @@ export default function useDeepgramTranscription() {
     currentTranscript: '',
     remainingSeconds: null,
     usedSeconds: 0,
+    scriptureResults: [],
   })
 
-  // Microphone loudness level, 0–100, updated every audio frame
   const micLevel = ref(0)
 
   let ws: WebSocket | null = null
   let audioContext: AudioContext | null = null
   let mediaStream: MediaStream | null = null
-  let processorNode: ScriptProcessorNode | null = null
-  let sessionStartTime: number | null = null
+  // Allow either an AudioWorkletNode (preferred) or a ScriptProcessorNode (fallback)
+  let workletNode: AudioWorkletNode | ScriptProcessorNode | null = null
+  let sourceNode: MediaStreamAudioSourceNode | null = null
   let sessionElapsedTimer: ReturnType<typeof setInterval> | null = null
   let usageSyncTimer: ReturnType<typeof setInterval> | null = null
+  let keepAliveTimer: ReturnType<typeof setInterval> | null = null
+  let lastAudioSentAt = 0
+
+  // Voice-command latch — prevents firing the same command repeatedly while
+  // the interim transcript still contains the trigger phrase.
+  let lastFiredCommand: 'next-verse' | 'previous-verse' | null = null
+  let lastCommandFiredAt = 0
+  const COMMAND_COOLDOWN_MS = 1500
+
+  // Auto-live cooldown — prevents rapid-fire slide switches when the preacher
+  // mentions several references in quick succession.
+  let lastAutoLiveAt = 0
+  const AUTO_LIVE_COOLDOWN_MS = 4000
 
   /**
-   * Detect voice commands in the transcript
+   * Detect voice commands in the transcript.
    */
   const detectVoiceCommand = (text: string): 'next-verse' | 'previous-verse' | null => {
-    const lowerText = text.toLowerCase().trim()
+    const lower = text.toLowerCase().trim()
     if (
-      lowerText.includes('next verse') ||
-      lowerText.includes('next first') ||
-      lowerText === 'next' ||
-      lowerText.includes('go to next verse') ||
-      lowerText.includes('go next verse')
-    ) {
-      return 'next-verse'
-    }
+      lower.includes('next verse') ||
+      lower.includes('next first') ||
+      lower === 'next' ||
+      lower.includes('go to next verse') ||
+      lower.includes('go next verse')
+    ) return 'next-verse'
+
     if (
-      lowerText.includes('previous verse') ||
-      lowerText.includes('last verse') ||
-      lowerText.includes('go back') ||
-      lowerText.includes('go to previous verse') ||
-      lowerText.includes('go to last verse') ||
-      lowerText.includes('go previous verse')
-    ) {
-      return 'previous-verse'
-    }
+      lower.includes('previous verse') ||
+      lower.includes('last verse') ||
+      lower.includes('go back') ||
+      lower.includes('go to previous verse') ||
+      lower.includes('go to last verse') ||
+      lower.includes('go previous verse')
+    ) return 'previous-verse'
+
     return null
   }
 
-  const executeVoiceCommand = (command: 'next-verse' | 'previous-verse') => {
-    if (command === 'next-verse') {
-      useGlobalEmit(appWideActions.nextVerse)
-    } else if (command === 'previous-verse') {
-      useGlobalEmit(appWideActions.previousVerse)
+  /**
+   * Fire the matching command, with a debounce so the same interim text
+   * doesn't trigger repeatedly. Reset the latch when text changes substantially.
+   */
+  const maybeFireVoiceCommand = (text: string) => {
+    const command = detectVoiceCommand(text)
+    if (!command) {
+      lastFiredCommand = null
+      return
     }
+    const now = Date.now()
+    if (command === lastFiredCommand && now - lastCommandFiredAt < COMMAND_COOLDOWN_MS) return
+    lastFiredCommand = command
+    lastCommandFiredAt = now
+    if (command === 'next-verse') useGlobalEmit(appWideActions.nextVerse)
+    else useGlobalEmit(appWideActions.previousVerse)
   }
 
-  const createSegmentFromText = (text: string) => {
+  const createSegmentFromText = (text: string, refsFromServer?: BibleReference[]) => {
     if (!text.trim()) return
-    const cleanedText = text.trim()
-    const voiceCommand = detectVoiceCommand(cleanedText)
-    if (voiceCommand) executeVoiceCommand(voiceCommand)
+    const cleaned = text.trim()
 
-    const references = useBibleReferenceParser(cleanedText)
-    const segment: TranscriptSegment = {
+    // Server-parsed references are authoritative when present.
+    // Fall back to the client parser only if the server didn't send any —
+    // useful during dev/local where the backend may be older.
+    const references = refsFromServer && refsFromServer.length > 0
+      ? refsFromServer
+      : useBibleReferenceParser(cleaned)
+
+    state.value.segments.push({
       id: useObjectID(),
-      text: cleanedText,
+      text: cleaned,
       timestamp: Date.now(),
       bibleReferences: references,
-    }
-    state.value.segments.push(segment)
+    })
     state.value.currentTranscript = ''
   }
 
+  // How many past WS pushes to keep visible. Results from older pushes are
+  // evicted so the panel stays focused on what's being said right now.
+  const MAX_SCRIPTURE_BATCHES = 2
+  const RESULTS_PER_BATCH = 5
+  let batchCounter = 0
+
   /**
-   * Build the WebSocket URL pointing to our backend proxy.
-   * Converts http(s) base URL → ws(s).
+   * Replace the visible scripture results with the latest push.
+   * Keeps up to MAX_SCRIPTURE_BATCHES worth of results so there is some
+   * continuity, but evicts anything older to avoid bloat.
+   * Within a batch results are ordered by the backend's relevance score.
    */
+  const mergeScriptureResults = (raw: any[]) => {
+    if (!raw?.length) return
+    const currentBatch = ++batchCounter
+
+    const incoming: ScriptureResult[] = raw.slice(0, RESULTS_PER_BATCH).map((r) => {
+      const bookIndex = Number(r.book)
+      const bookName = bibleBooks[bookIndex - 1] || `Book ${bookIndex}`
+      return {
+        ...r,
+        shortLabel: `${r.book}:${r.chapter}:${r.verse}`,
+        displayLabel: `${bookName} ${r.chapter}:${r.verse}`,
+        batchId: currentBatch,
+      }
+    })
+
+    // Evict batches that are too old, then prepend the new batch.
+    const cutoff = currentBatch - MAX_SCRIPTURE_BATCHES
+    const retained = state.value.scriptureResults.filter(
+      (x) => x.batchId > cutoff && !incoming.some((n) => n.shortLabel === x.shortLabel),
+    )
+    state.value.scriptureResults = [...incoming, ...retained]
+  }
+
+  /**
+   * Apply references parsed by the server into the most-recent matching segment
+   * and automatically go live with the first reference detected.
+   *
+   * A cooldown prevents rapid-fire slide switches when multiple references are
+   * mentioned in quick succession.
+   */
+  const applyServerReferences = (references: BibleReference[]) => {
+    if (!references?.length) return
+
+    const lastSegment = state.value.segments[state.value.segments.length - 1]
+    if (lastSegment) {
+      lastSegment.bibleReferences = references
+    }
+
+    // Auto go-live with the first reference if cooldown has elapsed.
+    const now = Date.now()
+    if (now - lastAutoLiveAt >= AUTO_LIVE_COOLDOWN_MS) {
+      lastAutoLiveAt = now
+      useGlobalEmit(appWideActions.updateOrCreateBible, references[0].shortLabel)
+    }
+  }
+
   const buildWsUrl = (churchId: string): string => {
     const baseUrl = (config.public.BASE_URL as string) || ''
-    // e.g. https://api.cloudofworship.com/api/v1 → wss://api.cloudofworship.com/api/v1
     const wsBase = baseUrl.replace(/^http/, 'ws')
     const token = useAuthToken().getToken()
     return `${wsBase}/church/${churchId}/transcription/stream?token=${token}`
   }
 
-  /**
-   * Convert Float32 PCM samples to Int16 for Deepgram (linear16 encoding).
-   */
-  const float32ToInt16 = (float32Array: Float32Array): ArrayBuffer => {
-    const int16Array = new Int16Array(float32Array.length)
-    for (let i = 0; i < float32Array.length; i++) {
-      const s = Math.max(-1, Math.min(1, float32Array[i] ?? 0))
-      int16Array[i] = s < 0 ? s * 0x8000 : s * 0x7fff
-    }
-    return int16Array.buffer
-  }
-
-  /**
-   * Fetch the current weekly usage from the API.
-   */
   const fetchUsage = async () => {
     const churchId = authStore.user?.churchId
     if (!churchId) return
@@ -140,9 +217,6 @@ export default function useDeepgramTranscription() {
     }
   }
 
-  /**
-   * Start Deepgram transcription session.
-   */
   const startTranscription = async () => {
     if (state.value.isTranscribing) {
       toast.add({ title: 'Already transcribing', icon: 'i-bx-info-circle' })
@@ -177,26 +251,24 @@ export default function useDeepgramTranscription() {
       return
     }
 
-    // Connect to backend WebSocket proxy
     try {
       const wsUrl = buildWsUrl(churchId)
       ws = new WebSocket(wsUrl)
       ws.binaryType = 'arraybuffer'
-
-      ws.onopen = () => {
-        // Audio capture starts once the server sends "ready"
-      }
 
       ws.onmessage = (event) => {
         try {
           const msg = JSON.parse(event.data)
 
           if (msg.type === 'ready') {
-            // Server is connected to Deepgram – start capturing audio
             state.value.remainingSeconds = msg.remainingSeconds
             state.value.isTranscribing = true
             state.value.isConnecting = false
-            sessionStartTime = Date.now()
+
+            // Pre-warm the scripture IndexedDB index so the first auto-live
+            // reference hits a hot cache instead of paying the 150–500 ms
+            // cold-build cost.
+            useScripture('43:3:16').catch(() => {})
 
             sessionElapsedTimer = setInterval(() => {
               if (state.value.remainingSeconds !== null && state.value.remainingSeconds > 0) {
@@ -205,10 +277,16 @@ export default function useDeepgramTranscription() {
               }
             }, 1000)
 
-            // Re-sync remaining time from the server every 60 s to prevent drift
-            usageSyncTimer = setInterval(() => {
-              fetchUsage()
-            }, 60_000)
+            usageSyncTimer = setInterval(fetchUsage, 60_000)
+
+            // KeepAlive — every 5s of true silence, send a frame so Deepgram
+            // doesn't time out the upstream socket.
+            keepAliveTimer = setInterval(() => {
+              if (ws?.readyState !== WebSocket.OPEN) return
+              if (Date.now() - lastAudioSentAt > 5_000) {
+                ws.send(JSON.stringify({ type: 'KeepAlive' }))
+              }
+            }, 5_000)
 
             startAudioCapture()
           } else if (msg.type === 'transcript') {
@@ -216,7 +294,13 @@ export default function useDeepgramTranscription() {
               createSegmentFromText(msg.transcript)
             } else {
               state.value.currentTranscript = msg.transcript
+              // Fire voice commands on interim for snappy response
+              maybeFireVoiceCommand(msg.transcript)
             }
+          } else if (msg.type === 'references') {
+            applyServerReferences(msg.references)
+          } else if (msg.type === 'scriptures') {
+            mergeScriptureResults(msg.results)
           } else if (msg.type === 'limit_reached') {
             toast.add({
               title: 'Weekly limit reached',
@@ -273,41 +357,76 @@ export default function useDeepgramTranscription() {
   }
 
   /**
-   * Start capturing microphone audio and streaming it over the WebSocket.
+   * Start AudioWorklet-based capture. The processor runs on a dedicated audio
+   * thread and posts ~32 ms Int16 PCM chunks to the main thread, which forwards
+   * them over the WebSocket.
    */
-  const startAudioCapture = () => {
+  const startAudioCapture = async () => {
     if (!mediaStream || !ws) return
 
     audioContext = new AudioContext({ sampleRate: 16000 })
-    const source = audioContext.createMediaStreamSource(mediaStream)
-    // ScriptProcessorNode is deprecated but still broadly supported and avoids
-    // AudioWorklet complexity. Buffer size 4096 gives good latency vs. overhead balance.
-    processorNode = audioContext.createScriptProcessor(4096, 1, 1)
 
-    processorNode.onaudioprocess = (e) => {
-      const pcmData = e.inputBuffer.getChannelData(0)
+    try {
+      await audioContext.audioWorklet.addModule('/audio-worklets/transcription-pcm-processor.js')
+    } catch (err) {
+      console.error('Failed to load AudioWorklet, falling back to ScriptProcessorNode:', err)
+      startAudioCaptureFallback()
+      return
+    }
 
-      // Compute RMS loudness and map to 0–100
-      let sum = 0
-      for (let i = 0; i < pcmData.length; i++) {
-        sum += (pcmData[i] ?? 0) * (pcmData[i] ?? 0)
-      }
-      const rms = Math.sqrt(sum / pcmData.length)
-      // RMS of speech typically peaks around 0.3; clamp and scale to 0–100
+    sourceNode = audioContext.createMediaStreamSource(mediaStream)
+    workletNode = new AudioWorkletNode(audioContext, 'transcription-pcm-processor')
+
+    workletNode.port.onmessage = (e) => {
+      const { audio, rms } = e.data as { audio: ArrayBuffer; rms: number }
+      // RMS of speech peaks around 0.3 — clamp and scale to 0–100
       micLevel.value = Math.min(100, Math.round((rms / 0.3) * 100))
 
       if (ws?.readyState === WebSocket.OPEN) {
-        ws.send(float32ToInt16(pcmData))
+        ws.send(audio)
+        lastAudioSentAt = Date.now()
       }
     }
 
-    source.connect(processorNode)
-    processorNode.connect(audioContext.destination)
+    sourceNode.connect(workletNode)
+    // We don't connect to destination — we don't want to play the mic back
   }
 
   /**
-   * Stop the current transcription session.
+   * Legacy ScriptProcessorNode capture — kept for older browsers that lack
+   * AudioWorklet (rare; Chrome/Edge/Firefox/Safari have all shipped it for years).
    */
+  const startAudioCaptureFallback = () => {
+    if (!mediaStream || !ws || !audioContext) return
+
+    const source = audioContext.createMediaStreamSource(mediaStream)
+    const processor = audioContext.createScriptProcessor(2048, 1, 1)
+
+    processor.onaudioprocess = (e) => {
+      const pcmData = e.inputBuffer.getChannelData(0)
+      let sum = 0
+      for (let i = 0; i < pcmData.length; i++) sum += (pcmData[i] ?? 0) ** 2
+      const rms = Math.sqrt(sum / pcmData.length)
+      micLevel.value = Math.min(100, Math.round((rms / 0.3) * 100))
+
+      const int16 = new Int16Array(pcmData.length)
+      for (let i = 0; i < pcmData.length; i++) {
+        const s = Math.max(-1, Math.min(1, pcmData[i] ?? 0))
+        int16[i] = s < 0 ? s * 0x8000 : s * 0x7fff
+      }
+      if (ws?.readyState === WebSocket.OPEN) {
+        ws.send(int16.buffer)
+        lastAudioSentAt = Date.now()
+      }
+    }
+
+    source.connect(processor)
+    processor.connect(audioContext.destination)
+    // Store on the same slots used by the teardown path
+    workletNode = processor
+    sourceNode = source
+  }
+
   const stopTranscription = () => {
     if (!state.value.isTranscribing && !state.value.isConnecting) return
 
@@ -319,62 +438,51 @@ export default function useDeepgramTranscription() {
     state.value.isTranscribing = false
     state.value.isConnecting = false
 
-    // Refresh usage from server after stopping
     fetchUsage()
   }
 
-  /**
-   * Release all resources.
-   */
   const cleanup = () => {
-    if (sessionElapsedTimer) {
-      clearInterval(sessionElapsedTimer)
-      sessionElapsedTimer = null
-    }
+    if (sessionElapsedTimer) { clearInterval(sessionElapsedTimer); sessionElapsedTimer = null }
+    if (usageSyncTimer)      { clearInterval(usageSyncTimer);      usageSyncTimer = null }
+    if (keepAliveTimer)      { clearInterval(keepAliveTimer);      keepAliveTimer = null }
 
-    if (usageSyncTimer) {
-      clearInterval(usageSyncTimer)
-      usageSyncTimer = null
+    if (workletNode) {
+      try { workletNode.disconnect() } catch {}
+      workletNode = null
     }
-
-    if (processorNode) {
-      processorNode.disconnect()
-      processorNode = null
+    if (sourceNode) {
+      try { sourceNode.disconnect() } catch {}
+      sourceNode = null
     }
-
     if (audioContext) {
-      audioContext.close().catch(() => { })
+      audioContext.close().catch(() => {})
       audioContext = null
     }
-
     if (mediaStream) {
       mediaStream.getTracks().forEach((t) => t.stop())
       mediaStream = null
     }
-
     if (ws) {
       if (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING) {
         ws.close()
       }
       ws = null
     }
-
     micLevel.value = 0
-
-    sessionStartTime = null
+    lastFiredCommand = null
   }
 
   const clearTranscript = () => {
     state.value.segments = []
     state.value.currentTranscript = ''
+    state.value.scriptureResults = []
+    batchCounter = 0
     toast.add({ title: 'Transcript cleared', icon: 'i-bx-trash' })
   }
 
   const allBibleReferences = computed(() => {
     const refs: BibleReference[] = []
-    for (const segment of state.value.segments) {
-      refs.push(...segment.bibleReferences)
-    }
+    for (const segment of state.value.segments) refs.push(...segment.bibleReferences)
     return refs
   })
 
@@ -382,10 +490,9 @@ export default function useDeepgramTranscription() {
     if (state.value.remainingSeconds === null) return null
     return Math.floor(state.value.remainingSeconds / 60)
   })
-
   const usedMinutes = computed(() => Math.floor(state.value.usedSeconds / 60))
 
-  // Fetch usage on composable initialisation
+  // Fetch usage lazily — only when the panel is opened, not on import
   fetchUsage()
 
   onUnmounted(() => {
@@ -404,6 +511,10 @@ export default function useDeepgramTranscription() {
     usedMinutes,
     allBibleReferences,
     micLevel: computed(() => micLevel.value),
+    // Scripture results streamed from the server over the same WS connection.
+    // The transcripts panel reads this for the "Scriptures" tab when on the
+    // Deepgram path (Teams plan / transcripts-free flag).
+    scriptureResults: computed(() => state.value.scriptureResults),
 
     startTranscription,
     stopTranscription,

--- a/app/composables/useFeatureFlags.ts
+++ b/app/composables/useFeatureFlags.ts
@@ -23,6 +23,10 @@ export const useFeatureFlags = (flagKey?: FeatureFlagKey) => {
    */
   const checkFlag = (key: FeatureFlagKey): boolean => {
     if (!posthog) {
+      // PostHog is not initialized on localhost — allow all flagged features
+      if (window.location.hostname === "localhost") {
+        return true
+      }
       console.warn("PostHog is not initialized")
       return false
     }
@@ -38,6 +42,10 @@ export const useFeatureFlags = (flagKey?: FeatureFlagKey) => {
    */
   const getFlagValue = (key: FeatureFlagKey): boolean | string | undefined => {
     if (!posthog) {
+      // PostHog is not initialized on localhost — treat all flags as enabled
+      if (window.location.hostname === "localhost") {
+        return true
+      }
       console.warn("PostHog is not initialized")
       return undefined
     }

--- a/app/composables/useLibrary.ts
+++ b/app/composables/useLibrary.ts
@@ -142,11 +142,6 @@ export default function useLibrary() {
       return mergedSlides
     } catch (error) {
       console.error('Error fetching saved slides:', error)
-      toast.add({
-        icon: 'i-bx-error',
-        title: 'Failed to fetch saved slides',
-        color: 'red',
-      })
       return []
     } finally {
       loading.value = false

--- a/app/composables/useScriptureSearch.ts
+++ b/app/composables/useScriptureSearch.ts
@@ -3,7 +3,7 @@ import { bibleBooks } from '~/utils/constants'
 import type { BibleReference } from '~/types/transcript'
 
 export interface ScriptureResult {
-  _id: string
+  _id?: string
   book: string      // 1-based string e.g. "43"
   chapter: string
   verse: string
@@ -82,10 +82,9 @@ export default function useScriptureSearch() {
         const payload = data.value as { results: any[] }
         const enriched = (payload.results || []).map(enrichResult)
 
-        // Merge new results — if a result already exists, move it into the
-        // current batch and refresh its score so it sorts correctly within it.
+        // Merge new results — dedup by shortLabel (book:chapter:verse).
         for (const item of enriched) {
-          const existing = results.value.find((r) => r._id === item._id)
+          const existing = results.value.find((r) => r.shortLabel === item.shortLabel)
           if (existing) {
             existing.batchId = currentBatch
             existing.score = item.score

--- a/app/composables/useSermonTranscription.ts
+++ b/app/composables/useSermonTranscription.ts
@@ -543,6 +543,13 @@ export default function useSermonTranscription() {
     isTeamsPlan,
     useDeepgramEngine,
 
+    // Scripture results streamed from the server (Deepgram path only).
+    // Falls back to an empty array for the Web Speech (free) path; the panel
+    // continues to use its own `useScriptureSearch` HTTP fetch there.
+    deepgramScriptureResults: computed(() =>
+      useDeepgramEngine.value ? deepgram.scriptureResults.value : [],
+    ),
+
     // Actions
     startTranscription,
     stopTranscription,

--- a/app/composables/useSlides.ts
+++ b/app/composables/useSlides.ts
@@ -36,13 +36,15 @@ export default function useSlides() {
   }
 
   const updateLiveOutput = (updatedSlide: Slide, options?: { forceGoLive: boolean }) => {
-    appStore.replaceScheduleActiveSlides(slides.value || [])
-
-    // If the current slide in the live output/slide schedule is being edited, then update LiveOutput immediately
+    // Post to the live window first — before any Pinia/localStorage work —
+    // so the projector sees the new slide as early as possible.
     if (updatedSlide.id === appStore.currentState.liveSlideId || options?.forceGoLive) {
       appStore.setLiveSlide(updatedSlide.id)
       useBroadcastPost(JSON.stringify(updatedSlide))
     }
+
+    // Persist schedule state after broadcasting (non-critical path).
+    appStore.replaceScheduleActiveSlides(slides.value || [])
   }
 
   /**

--- a/app/composables/useSlides.ts
+++ b/app/composables/useSlides.ts
@@ -136,12 +136,6 @@ export default function useSlides() {
       return data.value as Slide[]
     } catch (error: any) {
       console.error('Error getting saved slides:', error)
-      // toast.add({
-      //   icon: 'i-bx-error',
-      //   title: 'Failed to fetch saved slides',
-      //   description: error.message,
-      //   color: 'red',
-      // })
       return []
     } finally {
       loading.value = false

--- a/app/composables/useUserSettings.ts
+++ b/app/composables/useUserSettings.ts
@@ -87,6 +87,7 @@ export const useUserSettings = () => {
           footnotes: userSettings.footnotes,
           songAndHymnLabelsVisibility: userSettings.songAndHymnLabelsVisibility,
           liveWindowFullscreen: userSettings.liveWindowFullscreen,
+          closeLiveWindowWithOperator: userSettings.closeLiveWindowWithOperator,
           transitionInterval: userSettings.transitionInterval,
           alertLimit: userSettings.alertLimit,
         }
@@ -142,6 +143,7 @@ export const useUserSettings = () => {
         footnotes: settingsToSave.footnotes,
         songAndHymnLabelsVisibility: settingsToSave.songAndHymnLabelsVisibility,
         liveWindowFullscreen: settingsToSave.liveWindowFullscreen,
+        closeLiveWindowWithOperator: settingsToSave.closeLiveWindowWithOperator,
         transitionInterval: settingsToSave.transitionInterval,
         alertLimit: settingsToSave.alertLimit,
       }

--- a/app/layouts/app.vue
+++ b/app/layouts/app.vue
@@ -1098,9 +1098,12 @@ async function openWindows() {
       }
     }
 
-    // Also close our popup windows if the main app window is closed
+    // Close popup windows when the operator tab closes, but only when the user
+    // has opted into this behaviour (default is to leave the live window open)
     window.addEventListener("beforeunload", () => {
-      closeAllWindows()
+      if (appStore.currentState.settings.closeLiveWindowWithOperator) {
+        closeAllWindows()
+      }
     })
 
     screenDetails.addEventListener("screenschange", () => {

--- a/app/layouts/app.vue
+++ b/app/layouts/app.vue
@@ -57,7 +57,7 @@
             </span>
           </div>
 
-          <UProgress size="2xl" :value="overallLoadingProgress" :max="100" />
+          <UProgress size="2xl" :value="overallLoadingProgress || undefined" :max="100" />
 
           <div
             class="flex items-center justify-center gap-3 text-xs text-gray-500 dark:text-gray-400"
@@ -396,9 +396,7 @@ emitter.on("close-offline-toast", () => {
 
 emitter.on("selected-schedule", (schedule: Schedule) => {
   appStore.setSlidesLoading(true)
-  setTimeout(() => {
-    retrieveAllMediaFilesFromDB()
-  }, 2000)
+  retrieveAllMediaFilesFromDB()
 })
 
 emitter.on("go-live", async () => {
@@ -499,101 +497,95 @@ const fetchActiveAdvert = async () => {
 
 const downloadEssentialResources = async () => {
   const db = useIndexedDB()
-
   loadingResources.value = true
-  setLoadingTask("startup", "Refreshing account, church, and app settings.", 5)
+
+  // ── Phase 1: Critical path ────────────────────────────────────────────────
+  // Only what the workspace needs to render. Everything else runs in the
+  // background after the loading screen is dismissed.
+  setLoadingTask("startup", "Refreshing account, church, and schedules.", 5)
 
   if (online.value) {
+    // retrieveSchedules only needs authStore.churchId, which Pinia already
+    // has from the persisted session, so it's safe to run in parallel.
     await Promise.allSettled([
       fetchUser(),
       fetchChurch(),
-      fetchAppInfo(),
-      refreshLibrary(),
-      fetchPlans(),
+      retrieveSchedules(),
     ])
   } else {
-    setLoadingTask(
-      "startup",
-      "Offline: using saved account and app settings.",
-      100
-    )
+    setLoadingTask("startup", "Offline: using saved account and app settings.", 100)
+    await retrieveSchedules()
   }
-
-  if (online.value) {
-    await saveAllBackgroundVideos()
-  } else {
-    setLoadingTask("videos", "Offline: using cached background videos.", 100)
-  }
-
-  setLoadingTask("schedules", "Loading schedules and slides.", 0)
-  await retrieveSchedules()
-
-  setLoadingTask("bible", "Checking KJV Bible availability.", 10)
-  let tempBible = await db.bibleAndHymns.get("KJV")
-  if (!tempBible && online.value) {
-    setLoadingTask("bible", "Downloading KJV Bible for offline use.", 0)
-
-    try {
-      let kjvBible = await useDetailedFetch(
-        `https://d37gopmfkl2m2z.cloudfront.net/open/bible-versions/kjv.json`,
-        downloadProgress
-      )
-      kjvBible = await kjvBible.json()
-      await db.bibleAndHymns.add(tempBibleVersion("KJV", kjvBible))
-    } catch (err) {
-      console.warn("Failed to download KJV Bible (offline?):", err)
-    }
-  } else if (tempBible) {
-    setLoadingTask("bible", "KJV Bible is already available offline.", 100)
-  } else {
-    setLoadingTask("bible", "Offline: KJV Bible is not cached yet.", 100)
-  }
-
-  const { populateBibleVersionOptions } = useBibleVersionManager()
-  await populateBibleVersionOptions(
-    appInfo.value?.bibleVersions?.length
-      ? appInfo.value.bibleVersions
-      : undefined
-  )
-
-  await fetchHymns()
-
-  if (online.value && authStore.user?._id) {
-    setLoadingTask("bible", "Checking your preferred Bible version.", 90)
-    const userSettings = await fetchUserSettings()
-    const preferredVersion =
-      userSettings?.defaultBibleVersion ||
-      appStore.currentState.settings.defaultBibleVersion
-    if (preferredVersion && preferredVersion !== "KJV") {
-      const { isBibleVersionDownloaded, downloadBibleVersion } =
-        useBibleVersionManager()
-      const alreadyDownloaded = await isBibleVersionDownloaded(preferredVersion)
-      if (!alreadyDownloaded) {
-        setLoadingTask("bible", `Downloading ${preferredVersion} Bible.`, 0)
-        try {
-          await downloadBibleVersion(preferredVersion)
-        } catch (err) {
-          console.error(`Failed to auto-download ${preferredVersion}:`, err)
-        }
-      }
-    }
-  }
-
-  setLoadingTask("display", "Checking display setup for live projection.", 20)
-  await useAutoDetectSecondaryDisplay()
-  setLoadingTask("display", "Display setup is ready.", 100)
 
   setLoadingTask("ready", "Opening your workspace.", 100)
+  loadingResources.value = false
 
-  setTimeout(() => {
-    loadingResources.value = false
-    useGlobalEmit(
-      appWideActions.selectedSchedule,
-      appStore.currentState.activeSchedule?._id
-    )
-    overrideAppSettings()
-    appStore.refreshAppActionsStack()
-  }, 100)
+  await nextTick()
+  useGlobalEmit(
+    appWideActions.selectedSchedule,
+    appStore.currentState.activeSchedule?._id
+  )
+  overrideAppSettings()
+  appStore.refreshAppActionsStack()
+
+  // ── Phase 2: Background ───────────────────────────────────────────────────
+  // These run after the workspace is visible. Errors are isolated and non-fatal.
+  if (online.value) {
+    Promise.allSettled([
+      // App info then populate Bible version options (chained dependency)
+      fetchAppInfo().then(async () => {
+        const { populateBibleVersionOptions } = useBibleVersionManager()
+        await populateBibleVersionOptions(
+          appInfo.value?.bibleVersions?.length
+            ? appInfo.value.bibleVersions
+            : undefined
+        )
+      }),
+      refreshLibrary(),
+      fetchPlans(),
+      saveAllBackgroundVideos(),
+      // KJV Bible — only downloads once per device
+      (async () => {
+        const tempBible = await db.bibleAndHymns.get("KJV")
+        if (!tempBible) {
+          try {
+            let kjvBible = await useDetailedFetch(
+              `https://d37gopmfkl2m2z.cloudfront.net/open/bible-versions/kjv.json`,
+              downloadProgress
+            )
+            kjvBible = await kjvBible.json()
+            await db.bibleAndHymns.add(tempBibleVersion("KJV", kjvBible))
+          } catch (err) {
+            console.warn("Failed to download KJV Bible:", err)
+          }
+        }
+      })(),
+      fetchHymns(),
+      // User settings + preferred non-KJV Bible version
+      (async () => {
+        if (!authStore.user?._id) return
+        const userSettings = await fetchUserSettings()
+        const preferredVersion =
+          userSettings?.defaultBibleVersion ||
+          appStore.currentState.settings.defaultBibleVersion
+        if (preferredVersion && preferredVersion !== "KJV") {
+          const { isBibleVersionDownloaded, downloadBibleVersion } =
+            useBibleVersionManager()
+          const alreadyDownloaded = await isBibleVersionDownloaded(preferredVersion)
+          if (!alreadyDownloaded) {
+            try {
+              await downloadBibleVersion(preferredVersion)
+            } catch (err) {
+              console.error(`Failed to auto-download ${preferredVersion}:`, err)
+            }
+          }
+        }
+      })(),
+    ])
+
+    // Secondary display detection — fire and forget, go-live flows self-detect
+    useAutoDetectSecondaryDisplay()
+  }
 }
 
 const overrideAppSettings = async () => {

--- a/app/spa-loading-template.html
+++ b/app/spa-loading-template.html
@@ -126,7 +126,7 @@
       </div>
     </div>
 
-    <h2>Loading offline-ready resources</h2>
-    <div class="bar" aria-hidden="true"><span></span></div>
+    <!-- <h2>Loading offline-ready resources</h2>
+    <div class="bar" aria-hidden="true"><span></span></div> -->
   </section>
 </main>

--- a/app/store/app.ts
+++ b/app/store/app.ts
@@ -96,6 +96,7 @@ export const useAppStore = defineStore("app", {
           footnotes: false,
           songAndHymnLabelsVisibility: false,
           liveWindowFullscreen: true, // Default to fullscreen mode
+          closeLiveWindowWithOperator: false, // Default: live window stays open when operator tab closes
           // motionlessSlides: true,
           transitionInterval: 0.7,
           slideStyles: {
@@ -389,6 +390,12 @@ export const useAppStore = defineStore("app", {
         liveWindowFullscreen: fullscreen,
       }
       usePosthogCapture("LIVE_WINDOW_FULLSCREEN_SETTINGS_CHANGED")
+    },
+    setCloseLiveWindowWithOperator(value: boolean) {
+      this.currentState.settings = {
+        ...this.currentState.settings,
+        closeLiveWindowWithOperator: value,
+      }
     },
     setLinesPerSlide(lines: number) {
       this.currentState.settings = {

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -292,6 +292,7 @@ export interface AppSettings {
   footnotes?: boolean
   songAndHymnLabelsVisibility: boolean
   liveWindowFullscreen?: boolean // Whether live window opens in fullscreen mode
+  closeLiveWindowWithOperator?: boolean // Whether live window closes when operator tab closes (browser only)
 
   motionlessSlides?: boolean // deprecated
   transitionInterval?: number

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -97,6 +97,9 @@ export default defineNuxtConfig({
     clearScreen: false,
     // Enable environment variables
     envPrefix: ['VITE_', 'TAURI_'],
+    build: {
+      sourcemap: true,
+    },
   },
 
   runtimeConfig: {

--- a/public/audio-worklets/transcription-pcm-processor.js
+++ b/public/audio-worklets/transcription-pcm-processor.js
@@ -1,0 +1,52 @@
+/**
+ * AudioWorkletProcessor that converts Float32 mic samples to Int16 PCM and
+ * posts them to the main thread for the transcription WebSocket to forward
+ * to Deepgram.
+ *
+ * Runs on a dedicated audio thread → no main-thread jank during UI updates.
+ *
+ * Buffer size: AudioWorklet processes in 128-sample chunks by default. We
+ * accumulate ~4 of those (512 samples = 32ms at 16kHz) before posting, which
+ * cuts latency roughly 8× vs the old ScriptProcessorNode (4096 = 256ms) while
+ * keeping postMessage overhead low.
+ */
+class TranscriptionPCMProcessor extends AudioWorkletProcessor {
+  constructor() {
+    super()
+    this.buffer = new Int16Array(512)
+    this.bufferIndex = 0
+  }
+
+  process(inputs) {
+    const channel = inputs[0]?.[0]
+    if (!channel) return true
+
+    // RMS for visualiser (sent piggybacked on each post)
+    let sumSquares = 0
+
+    for (let i = 0; i < channel.length; i++) {
+      const sample = channel[i] ?? 0
+      sumSquares += sample * sample
+
+      // Clamp + convert Float32 [-1, 1] → Int16
+      const clamped = Math.max(-1, Math.min(1, sample))
+      this.buffer[this.bufferIndex++] = clamped < 0 ? clamped * 0x8000 : clamped * 0x7fff
+
+      if (this.bufferIndex >= this.buffer.length) {
+        // Transfer the underlying ArrayBuffer (zero-copy) and allocate a fresh one
+        const rms = Math.sqrt(sumSquares / channel.length)
+        this.port.postMessage(
+          { audio: this.buffer.buffer, rms },
+          [this.buffer.buffer],
+        )
+        this.buffer = new Int16Array(512)
+        this.bufferIndex = 0
+        sumSquares = 0
+      }
+    }
+
+    return true
+  }
+}
+
+registerProcessor('transcription-pcm-processor', TranscriptionPCMProcessor)

--- a/public/loading.html
+++ b/public/loading.html
@@ -126,7 +126,7 @@
       </div>
     </div>
 
-    <h2>Loading offline-ready resources</h2>
-    <div class="bar" aria-hidden="true"><span></span></div>
+    <!-- <h2>Loading offline-ready resources</h2>
+    <div class="bar" aria-hidden="true"><span></span></div> -->
   </section>
 </main>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Cloud of Worship",
-  "version": "0.50.2",
+  "version": "0.50.3",
   "identifier": "com.cloudofworship.app",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
### Overview
The transcription feature now drives the projector automatically — spoken Bible references open and project the correct slide with no manual interaction. Scripture suggestions are pushed from the server over the existing WebSocket connection, eliminating HTTP polls. Multiple accuracy, latency, and UX improvements across the transcription composables and panel.

---

### Auto go-live on spoken references (`app/composables/useDeepgramTranscription.ts`)

- When the server pushes a `references` message, the app automatically emits `updateOrCreateBible` with the first detected reference
- A 4-second cooldown (`AUTO_LIVE_COOLDOWN_MS`) prevents rapid-fire slide switches when multiple references are mentioned in quick succession
- Manual reference clicks in the transcript still work exactly as before

**`app/components/PreviewContent.vue` — `update-or-create-bible` handler:**
- `useScripture(shortLabel)` resolves the numeric shortLabel (e.g. `"1:28:19"`) to the human-readable format (`"Genesis 28:19"`) required by `gotoVerse` — fixes a bug where clicking a reference navigated to the wrong verse
- Update path and create path share the same `useScripture` lookup then diverge cleanly
- `appStore.setRecentBibleSearches` called once after both paths

---

### Scripture results pane — newest first, not bloated (`app/composables/useDeepgramTranscription.ts`)

- `batchId` now increments **once per WS push** (was per-item) — all results from a single segment share a batch so the backend's relevance score correctly orders them within the group
- Incoming push replaces stale results: keeps the latest **2 batches × 5 results = 10 items** max, evicting anything older
- `applyServerReferences` no longer inserts synthesized scripture cards into the Scriptures pane — references are already highlighted inline in the transcript; removing them from the pane eliminates race conditions with ranked AI results

---

### AudioWorklet audio capture (`public/audio-worklets/transcription-pcm-processor.js`) — NEW

- Runs on a dedicated audio thread (off the main thread)
- 512-sample Int16 buffer (~32ms at 16kHz) — ~8× lower latency vs the old `ScriptProcessorNode` 256ms chunks
- Computes RMS for mic level visualization
- Zero-copy `ArrayBuffer` transfer to main thread
- `ScriptProcessorNode` fallback kept for older browsers

---

### KeepAlive + silence handling (`app/composables/useDeepgramTranscription.ts`)

- Sends `{ type: "KeepAlive" }` every 5s when no audio has been sent, preventing Deepgram from timing out the upstream socket during sermon pauses

---

### Voice command detection (`app/composables/useDeepgramTranscription.ts`)

- Fires on **interim** results — "next verse" / "previous verse" commands trigger immediately without waiting for utterance end
- Fire-once cooldown latch (`lastFiredCommand`, 1500ms) prevents repeated triggers while the phrase remains in the interim buffer

---

### Scripture search dedup fix (`app/composables/useScriptureSearch.ts`)

- Dedup key changed from `_id` (no longer returned by the backend) to `shortLabel` (`book:chapter:verse`) — fixes a bug where only the first of 20 search results was ever displayed (all others collapsed into it via `undefined === undefined`)
- `ScriptureResult._id` typed as optional

---

### Scripture index pre-warm (`app/composables/useDeepgramTranscription.ts`)

- Fires a throwaway `useScripture('43:3:16')` call when the session becomes ready, forcing IndexedDB to build and cache the scripture index before the first reference is spoken
- Eliminates the 150–500ms cold-build cost on the first auto-live reference

---

### BroadcastChannel post before Pinia persist (`app/composables/useSlides.ts`)

- In `updateLiveOutput`, `useBroadcastPost` (drives the projector window) now fires before `appStore.replaceScheduleActiveSlides` (localStorage persistence)
- Shaves 10–50ms off the time between `makeSlideActive` and the projector rendering the new slide

---

### Feature flag local dev (`app/composables/useFeatureFlags.ts`)

- `checkFlag` and `getFlagValue` return `true` when PostHog is not initialized (localhost) — all feature-flagged actions including Transcribe Sermon are accessible in local development without needing PostHog enabled

---

### QuickActions skeleton loader (`app/components/QuickActions.vue`)

- Shows 20 skeleton rows while `getAllHymns()` hydrates from IndexedDB on initial load
- Skeletons match the ActionCard layout (icon circle + two text lines)
- `loading` flag set to `false` once the async hydration completes

---

### `app/components/live/TranscriptsPanel.vue`

- Deepgram path skips local reference parsing and HTTP scripture search — server handles both
- Web Speech path maintains existing HTTP search unchanged
- `visibleScriptureResults` sort (`batchId desc → score desc`) works correctly now that `batchId` is per-push
- `handleClear` resets both Deepgram scripture results and HTTP results