### PR TITLE
Fix settings modal save loop and OtherSettings alert slider

### DIFF
--- a/app/components/settings/OtherSettings.vue
+++ b/app/components/settings/OtherSettings.vue
@@ -14,16 +14,11 @@
         >
           <span class="text-sm whitespace-nowrap">5</span>
           <URange
-            :model-value="currentState.settings.transitionInterval"
+            :model-value="currentState.settings.alertLimit ?? 5"
             :min="5"
             :max="30"
             :step="1"
-            @change="
-              appStore.setAppSettings({
-                ...appStore.currentState.settings,
-                alertLimit: $event,
-              })
-            "
+            @change="updateSetting('alertLimit', Number($event))"
           />
           <span class="text-sm whitespace-nowrap"> 30</span>
         </div>

--- a/app/composables/useUserSettings.ts
+++ b/app/composables/useUserSettings.ts
@@ -20,7 +20,14 @@ export const useUserSettings = () => {
    */
   const saveSettingsLocally = (settings: AppSettings) => {
     lastLocalSaveTimestamp = Date.now()
-    appStore.setAppSettings(settings)
+
+    // When this is called from a watcher that is already responding to the
+    // current store settings, writing the same settings back into Pinia creates
+    // a new object reference and retriggers the watcher indefinitely. Only write
+    // to the store when the caller is providing a distinct settings object.
+    if (settings !== appStore.currentState.settings) {
+      appStore.setAppSettings(settings)
+    }
   }
 
   /**


### PR DESCRIPTION
### Motivation
- Prevent the Settings modal from hanging due to an infinite save/watch loop when the store is written with the same settings object reference repeatedly.
- Correct the alert-limit slider in Other Settings which was incorrectly bound to the slide `transitionInterval` and was writing the wrong value shape into the store.

### Description
- Add a guard in `saveSettingsLocally` (`app/composables/useUserSettings.ts`) to only call `appStore.setAppSettings` when the incoming `settings` object is not the same reference as `appStore.currentState.settings`, avoiding retriggering deep watchers.
- Fix `OtherSettings.vue` (`app/components/settings/OtherSettings.vue`) to bind the range to `currentState.settings.alertLimit ?? 5` and to save the value using `updateSetting('alertLimit', Number($event))` so the slider updates and persists the numeric `alertLimit` field.
- Changes are limited to `app/composables/useUserSettings.ts` and `app/components/settings/OtherSettings.vue`.

### Testing
- Ran `npm run build` and the production build completed successfully.
- Ran `npx vue-tsc --noEmit` which failed with existing unrelated TypeScript errors elsewhere in the repo; the failures are pre-existing and not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a239e9b1ac8832baff1e0946b85a3f4)