### PR TITLE
feat(songs): "did you mean?" duplicate UX in Add Song

### DIFF
--- a/app/components/songs/AddSong.vue
+++ b/app/components/songs/AddSong.vue
@@ -8,6 +8,88 @@
         <UInput placeholder="Nathaniel Bassey" v-model="artist" />
       </UFormGroup>
 
+      <!-- Proactive duplicate check: existing matches surfaced as the user types -->
+      <div
+        v-if="!song && similarSongs.length"
+        class="rounded-md border border-primary-200 dark:border-primary-800 bg-primary-50 dark:bg-primary-900/40 p-3"
+      >
+        <div
+          class="text-sm font-semibold flex items-center gap-2 text-primary-600 dark:text-primary-300"
+        >
+          <IconWrapper name="i-bx-search-alt" size="4" />
+          Is your song already here?
+        </div>
+        <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+          Tap one to use it instead of adding a duplicate.
+        </p>
+        <div class="mt-2 flex flex-col gap-1">
+          <div
+            v-for="match in similarSongs"
+            :key="match.id"
+            class="rounded-md overflow-hidden"
+          >
+            <div
+              class="flex items-center gap-2 p-2 hover:bg-primary-100 dark:hover:bg-primary-800/50 transition-colors"
+            >
+              <button
+                type="button"
+                class="flex items-center gap-2 min-w-0 flex-1 text-left"
+                @click="togglePreview(match.id)"
+              >
+                <IconWrapper
+                  name="i-bx-music"
+                  class="text-primary shrink-0"
+                  rounded-bg
+                />
+                <div class="min-w-0">
+                  <p class="font-medium truncate">{{ match.title }}</p>
+                  <p class="text-xs text-gray-500 truncate">
+                    {{ match.artist }}
+                  </p>
+                </div>
+                <IconWrapper
+                  :name="
+                    expandedId === match.id
+                      ? 'i-bx-chevron-up'
+                      : 'i-bx-chevron-down'
+                  "
+                  size="4"
+                  class="text-gray-400 ml-1 shrink-0"
+                />
+              </button>
+              <UButton
+                size="2xs"
+                color="primary"
+                variant="soft"
+                @click="useExistingSong(match)"
+              >
+                Use this
+              </UButton>
+            </div>
+            <p
+              v-if="expandedId === match.id"
+              class="px-3 pb-2 text-xs text-gray-500 dark:text-gray-400 whitespace-pre-line max-h-32 overflow-y-auto"
+            >
+              {{ match.lyrics || "No lyrics preview available." }}
+            </p>
+          </div>
+        </div>
+
+        <!-- Shown only after a near-dup blocked the submit (warn-don't-block) -->
+        <UButton
+          v-if="canForce"
+          block
+          size="sm"
+          variant="outline"
+          color="gray"
+          class="mt-2"
+          :loading="loading"
+          @click="addAnyway"
+        >
+          None of these — add anyway
+        </UButton>
+      </div>
+
       <div
         class="active-alert rounded-md bg-primary-100 dark:bg-primary-900 p-4"
       >
@@ -48,7 +130,7 @@
         class="mt-4"
         :disabled="!(artist && title && lyrics)"
         :loading="loading"
-        @click="addSong"
+        @click="addSong()"
       >
         {{ song ? "Edit Song" : "Add Song" }}
       </UButton>
@@ -56,6 +138,7 @@
   </div>
 </template>
 <script setup lang="ts">
+import { watchDebounced, useOnline } from "@vueuse/core"
 import { useAuthStore } from "~/store/auth"
 import type { Song } from "~/types"
 
@@ -64,16 +147,51 @@ const props = defineProps<{
 }>()
 
 const { saveSong } = useLibrary()
+const { findSimilarSongs } = useSongs()
 const loading = ref<boolean>(false)
 const artist = ref<string>(props.song?.artist || "")
 const title = ref<string>(props.song?.title || "")
 const lyrics = ref<string>(props.song?.lyrics || "")
 const isSongPublic = ref<boolean>(props.song?.isPublic || true)
+const similarSongs = ref<Song[]>([])
+const expandedId = ref<string>("")
+// True once a *near*-duplicate blocked the submit — lets the user override.
+const canForce = ref<boolean>(false)
 const toast = useToast()
 const emit = defineEmits(["go-home"])
 const authStore = useAuthStore()
+const online = useOnline()
 
-const addSong = async () => {
+// Surface existing matches as the user types title/artist/lyrics (debounced) —
+// lyrics are the strongest signal — so they can reuse a song instead of creating
+// a duplicate. Skipped while editing or offline.
+watchDebounced(
+  [title, artist, lyrics],
+  async ([newTitle, newArtist, newLyrics]) => {
+    // Editing the song invalidates a prior "blocked" state.
+    canForce.value = false
+    if (props.song || !online.value) {
+      similarSongs.value = []
+      return
+    }
+    similarSongs.value = await findSimilarSongs(newTitle, newArtist, newLyrics)
+  },
+  { debounce: 400 }
+)
+
+const togglePreview = (id: string) => {
+  expandedId.value = expandedId.value === id ? "" : id
+}
+
+const useExistingSong = (existing: Song) => {
+  useGlobalEmit(appWideActions.newSong, { ...existing, fromSaved: false })
+  emit("go-home")
+}
+
+// "Add anyway" — re-submit past the near-duplicate warning.
+const addAnyway = () => addSong(true)
+
+const addSong = async (force = false) => {
   const songId =
     props?.song?.id || useURLFriendlyString(`${title.value} ${artist.value}`)
   const song: Song = {
@@ -86,60 +204,94 @@ const addSong = async () => {
     updatedAt: new Date().toISOString(),
   }
 
+  loading.value = true
   try {
-    loading.value = true
-
-    // Save song to library using composable
-    await saveSong(song)
-
-    // Upload to API if it's a new song
-    if (!props.song) {
-      await uploadSongToAPI(song)
-    } else {
-      // For editing, just emit go-home
+    // Editing an existing song updates the local copy only (current behaviour).
+    if (props.song) {
+      await saveSong(song)
       emit("go-home")
+      return
+    }
+
+    // Offline: save locally; the API layer queues the upload to retry later.
+    if (!online.value) {
+      await saveSong(song)
+      toast.add({
+        icon: "i-bx-cloud",
+        title: "Saved locally — will sync when you're back online",
+      })
+      emit("go-home")
+      return
+    }
+
+    // Online: upload first so we honour the server's dedup result before saving.
+    const outcome = await uploadSongToAPI(song, force)
+    if (outcome.ok) {
+      await saveSong(song)
+      toast.add({ icon: "i-bx-check", title: "Song added" })
+      emit("go-home")
+    } else if (outcome.duplicates?.length) {
+      // Keep the form open, show the matches, and offer "add anyway" for a
+      // near-duplicate (exact duplicates aren't force-able — reuse instead).
+      similarSongs.value = outcome.duplicates
+      canForce.value = outcome.canForce ?? false
+      toast.add({
+        icon: "i-bx-error",
+        title: canForce.value
+          ? "Possible duplicate found"
+          : "This song already exists",
+        description: canForce.value
+          ? "Reuse one below, or add anyway."
+          : "Use the existing one below.",
+      })
     }
   } catch (err: any) {
     console.error("Error adding song:", err)
-  } finally {
-    loading.value = false
-  }
-}
-
-const uploadSongToAPI = async (song: Song) => {
-  try {
-    const { data, error } = await useAPIFetch(
-      `/church/${authStore.user?.churchId}/songs`,
-      {
-        method: "POST",
-        body: {
-          ...song,
-          isPublic: isSongPublic.value,
-          createdBy: authStore.user?._id,
-          churchId: authStore.user?.churchId,
-        },
-      }
-    )
-
-    // If error occurred
-    if (error.value) {
-      toast.add({
-        icon: "i-bx-error",
-        title: error.value.data?.message || "Failed to upload song",
-        color: "red",
-      })
-    } else {
-      emit("go-home")
-    }
-  } catch (err: any) {
-    console.error("Error uploading song to API:", err)
     toast.add({
       icon: "i-bx-error",
-      title: "Failed to upload song",
+      title: "Something went wrong adding the song",
       color: "red",
     })
   } finally {
     loading.value = false
   }
+}
+
+const uploadSongToAPI = async (
+  song: Song,
+  force = false
+): Promise<{ ok: boolean; duplicates?: Song[]; canForce?: boolean }> => {
+  const { error } = await useAPIFetch(
+    `/church/${authStore.user?.churchId}/songs`,
+    {
+      method: "POST",
+      body: {
+        ...song,
+        force,
+        isPublic: isSongPublic.value,
+        createdBy: authStore.user?._id,
+        churchId: authStore.user?.churchId,
+      },
+    }
+  )
+
+  if (!error.value) return { ok: true }
+
+  const data: any = error.value.data
+  // 409 = the server's dedup guard. A near-dup carries `possibleDuplicates` and
+  // is force-able; an exact dup carries `song` and is not (reuse it instead).
+  if (error.value.statusCode === 409) {
+    if (data?.possibleDuplicates?.length) {
+      return { ok: false, duplicates: data.possibleDuplicates, canForce: true }
+    }
+    return { ok: false, duplicates: data?.song ? [data.song] : [], canForce: false }
+  }
+
+  toast.add({
+    icon: "i-bx-error",
+    title: data?.message || "Failed to upload song",
+    color: "red",
+  })
+  return { ok: false }
 }
 </script>

--- a/app/components/songs/AddSong.vue
+++ b/app/components/songs/AddSong.vue
@@ -11,7 +11,7 @@
       <!-- Proactive duplicate check: existing matches surfaced as the user types -->
       <div
         v-if="!song && similarSongs.length"
-        class="rounded-md border border-primary-200 dark:border-primary-800 bg-primary-50 dark:bg-primary-900/40 p-3"
+        class="rounded-md bg-primary-50 dark:bg-primary-900/40 p-3"
       >
         <div
           class="text-sm font-semibold flex items-center gap-2 text-primary-600 dark:text-primary-300"
@@ -19,9 +19,6 @@
           <IconWrapper name="i-bx-search-alt" size="4" />
           Is your song already here?
         </div>
-        <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
-          Tap one to use it instead of adding a duplicate.
-        </p>
         <div class="mt-2 flex flex-col gap-1">
           <div
             v-for="match in similarSongs"
@@ -36,11 +33,6 @@
                 class="flex items-center gap-2 min-w-0 flex-1 text-left"
                 @click="togglePreview(match.id)"
               >
-                <IconWrapper
-                  name="i-bx-music"
-                  class="text-primary shrink-0"
-                  rounded-bg
-                />
                 <div class="min-w-0">
                   <p class="font-medium truncate">{{ match.title }}</p>
                   <p class="text-xs text-gray-500 truncate">
@@ -66,12 +58,18 @@
                 Use this
               </UButton>
             </div>
-            <p
-              v-if="expandedId === match.id"
-              class="px-3 pb-2 text-xs text-gray-500 dark:text-gray-400 whitespace-pre-line max-h-32 overflow-y-auto"
-            >
-              {{ match.lyrics || "No lyrics preview available." }}
-            </p>
+            <Transition name="duplicate-preview">
+              <div
+                v-if="expandedId === match.id"
+                class="duplicate-lyrics-frame relative px-0 pb-2"
+              >
+                <p
+                  class="duplicate-lyrics-preview text-xs whitespace-pre-line max-h-32 overflow-y-auto rounded-md px-2 py-2"
+                >
+                  {{ match.lyrics || "No lyrics preview available." }}
+                </p>
+              </div>
+            </Transition>
           </div>
         </div>
 
@@ -284,7 +282,11 @@ const uploadSongToAPI = async (
     if (data?.possibleDuplicates?.length) {
       return { ok: false, duplicates: data.possibleDuplicates, canForce: true }
     }
-    return { ok: false, duplicates: data?.song ? [data.song] : [], canForce: false }
+    return {
+      ok: false,
+      duplicates: data?.song ? [data.song] : [],
+      canForce: false,
+    }
   }
 
   toast.add({
@@ -295,3 +297,46 @@ const uploadSongToAPI = async (
   return { ok: false }
 }
 </script>
+
+<style scoped>
+.duplicate-preview-enter-active,
+.duplicate-preview-leave-active {
+  max-height: 10rem;
+  opacity: 1;
+  overflow: hidden;
+  transition: max-height 0.2s ease, opacity 0.16s ease;
+}
+
+.duplicate-preview-enter-from,
+.duplicate-preview-leave-to {
+  max-height: 0;
+  opacity: 0;
+}
+
+.duplicate-lyrics-frame::before,
+.duplicate-lyrics-frame::after {
+  content: "";
+  position: absolute;
+  left: 0.5rem;
+  right: 0.5rem;
+  height: 1rem;
+  pointer-events: none;
+  z-index: 1;
+}
+
+.duplicate-lyrics-frame::before {
+  top: 0;
+  border-radius: 0.375rem 0.375rem 0 0;
+  box-shadow: inset 0 10px 10px -12px rgb(15 23 42 / 0.1);
+}
+
+.duplicate-lyrics-frame::after {
+  bottom: 0.5rem;
+  border-radius: 0 0 0.375rem 0.375rem;
+  box-shadow: inset 0 -14px 12px -14px rgb(15 23 42 / 0.15);
+}
+
+.duplicate-lyrics-preview {
+  scrollbar-gutter: stable;
+}
+</style>

--- a/app/composables/useSongs.ts
+++ b/app/composables/useSongs.ts
@@ -54,6 +54,35 @@ export default function useSongs() {
   }
 
   /**
+   * Proactive duplicate check: returns existing songs that look like duplicates
+   * of the given title (similarity-filtered server-side, so it's empty for a
+   * genuinely new song). Stays quiet on error — it's a non-blocking hint.
+   */
+  const findSimilarSongs = async (
+    title: string,
+    artist = '',
+    lyrics = ''
+  ): Promise<Song[]> => {
+    const query = title?.trim()
+    if (!query || query.length < 2) return []
+    try {
+      // POST so the full lyrics (the strongest signal, too long for a URL) ride
+      // in the body. Returns only genuine near-duplicates, empty for a new song.
+      const { data, error } = await useAPIFetch(
+        `/church/${churchId}/songs/duplicates`,
+        {
+          method: 'POST',
+          body: { title: query, artist: artist?.trim(), lyrics: lyrics?.trim(), churchId },
+        }
+      )
+      if (error.value) return []
+      return ((data.value as any)?.data?.data || []) as Song[]
+    } catch {
+      return []
+    }
+  }
+
+  /**
    * Get all songs for the church
    */
   const getAllSongs = async (): Promise<Song[]> => {
@@ -332,6 +361,7 @@ export default function useSongs() {
     loading,
     songs,
     searchSongs,
+    findSimilarSongs,
     getAllSongs,
     getSongsCount,
     getSongById,


### PR DESCRIPTION
As the user types title/artist/lyrics (debounced), surface likely existing songs via POST /song/duplicates — each with a lyric preview and "Use this" to adopt instead of duplicating. On submit, upload first and honour the server's dedup result: an exact dup says "already exists" (reuse it), a near-dup offers "add anyway" (force). Offline saves locally.